### PR TITLE
fix: make login timeout alarm optional for Windows (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-09
+
+### Fixed
+- **`login()` crashed on Windows** — `AttributeError: module 'signal' has no attribute 'SIGALRM'` (fixes [#16](https://github.com/jamestford/pyhood/issues/16))
+  - The login timeout was armed with `signal.SIGALRM`, which exists only on Unix
+  - The alarm is now best-effort: skipped when `SIGALRM` is unavailable, so login works on Windows
+  - Also skipped when `login()` is called off the main thread, where `signal.signal()` raises `ValueError`
+  - Timeouts are still enforced on those platforms by the verification poll loop and per-request HTTP timeouts
+  - Alarm setup/teardown moved into a context manager, so the handler is always restored
+  - 4 new tests (227 total) simulating a Windows environment and a worker thread
+
 ## [0.8.0] - 2026-08-09
 
 ### Fixed

--- a/pyhood/__init__.py
+++ b/pyhood/__init__.py
@@ -1,6 +1,6 @@
 """pyhood — A modern, reliable Python client for the Robinhood API."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 from pyhood.auth import login, logout, refresh
 from pyhood.client import PyhoodClient

--- a/pyhood/auth.py
+++ b/pyhood/auth.py
@@ -14,6 +14,8 @@ import logging
 import secrets
 import signal
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +37,41 @@ CLIENT_ID = "c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS"
 # Default token storage
 DEFAULT_TOKEN_DIR = Path.home() / ".pyhood"
 DEFAULT_TOKEN_FILE = "session.json"
+
+
+@contextmanager
+def _login_alarm(timeout: float) -> Iterator[None]:
+    """Best-effort wall-clock alarm around a blocking login call.
+
+    SIGALRM exists only on Unix and can only be armed from the main thread,
+    so this is a no-op on Windows or in a worker thread. The verification
+    poll loop and the per-request HTTP timeouts still bound the flow there;
+    the alarm is an extra guard, not the only one.
+    """
+    if timeout <= 0 or not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    def _timeout_handler(signum: int, frame: Any) -> None:
+        raise LoginTimeout(
+            f"Login timed out after {timeout}s. "
+            "Robinhood may be waiting for device approval — check the Robinhood app."
+        )
+
+    try:
+        original_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+    except ValueError:
+        # Signal handlers can only be installed from the main thread
+        logger.debug("Not on the main thread — login alarm disabled")
+        yield
+        return
+
+    signal.alarm(int(timeout))
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, original_handler)
 
 
 def generate_device_token() -> str:
@@ -325,18 +362,7 @@ def login(
     if mfa_code:
         login_payload["mfa_code"] = mfa_code
 
-    # Set timeout alarm (Unix only)
-    original_handler = None
-    if timeout > 0:
-        def _timeout_handler(signum, frame):
-            raise LoginTimeout(
-                f"Login timed out after {timeout}s. "
-                "Robinhood may be waiting for device approval — check the Robinhood app."
-            )
-        original_handler = signal.signal(signal.SIGALRM, _timeout_handler)
-        signal.alarm(int(timeout))
-
-    try:
+    with _login_alarm(timeout):
         # Robinhood login returns 400/403 with valid JSON (verification data)
         login_accept = (400, 401, 402, 403)
         data = session.post(urls.LOGIN, data=login_payload, accept_codes=login_accept)
@@ -370,13 +396,6 @@ def login(
         _active_store = store
         logger.info("Login successful")
         return session
-
-    finally:
-        # Clear alarm
-        if timeout > 0:
-            signal.alarm(0)
-            if original_handler is not None:
-                signal.signal(signal.SIGALRM, original_handler)
 
 
 def refresh(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["pyhood"]
 
 [project]
 name = "pyhood"
-version = "0.8.0"
+version = "0.8.1"
 description = "A modern, reliable Python client for the Robinhood API"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
 """Tests for authentication — token store, login flow, error handling."""
 
 import json
+import signal
 import time
 from pathlib import Path
 
@@ -8,7 +9,15 @@ import pytest
 import responses
 
 from pyhood import urls
-from pyhood.auth import TokenStore, generate_device_token, get_session, login, logout, refresh
+from pyhood.auth import (
+    TokenStore,
+    _login_alarm,
+    generate_device_token,
+    get_session,
+    login,
+    logout,
+    refresh,
+)
 from pyhood.exceptions import AuthError, TokenExpiredError
 
 
@@ -303,6 +312,76 @@ class TestLoginFlow:
 
         assert session.is_authenticated
         assert not token_path.exists()
+
+
+class TestLoginAlarm:
+    """SIGALRM is Unix/main-thread only — login must work without it (#16)."""
+
+    def _login_response(self):
+        responses.add(
+            responses.POST,
+            urls.LOGIN,
+            json={
+                "access_token": "win-access-token",
+                "token_type": "Bearer",
+                "refresh_token": "win-refresh-token",
+                "expires_in": 86400,
+                "scope": "internal",
+            },
+            status=200,
+        )
+
+    @responses.activate
+    def test_login_without_sigalrm(self, monkeypatch, tmp_path):
+        """Windows: signal has no SIGALRM at all."""
+        monkeypatch.delattr(signal, "SIGALRM", raising=False)
+        monkeypatch.delattr(signal, "alarm", raising=False)
+        self._login_response()
+
+        session = login(
+            username="test@example.com",
+            password="testpass",
+            timeout=10,
+            token_path=tmp_path / "session.json",
+        )
+        assert session.is_authenticated
+
+    @responses.activate
+    def test_login_off_main_thread(self, monkeypatch, tmp_path):
+        """Worker thread: signal.signal raises ValueError."""
+        def _raise(*args, **kwargs):
+            raise ValueError("signal only works in main thread")
+
+        monkeypatch.setattr(signal, "signal", _raise)
+        self._login_response()
+
+        session = login(
+            username="test@example.com",
+            password="testpass",
+            timeout=10,
+            token_path=tmp_path / "session.json",
+        )
+        assert session.is_authenticated
+
+    def test_alarm_cleared_on_exception(self):
+        """The alarm is disarmed and the handler restored even if the body raises."""
+        if not hasattr(signal, "SIGALRM"):
+            pytest.skip("SIGALRM unavailable on this platform")
+
+        original = signal.getsignal(signal.SIGALRM)
+        with pytest.raises(RuntimeError):
+            with _login_alarm(30):
+                raise RuntimeError("boom")
+
+        assert signal.getsignal(signal.SIGALRM) is original
+
+    def test_no_alarm_when_timeout_disabled(self, monkeypatch):
+        """timeout=0 must not arm an alarm."""
+        armed = []
+        monkeypatch.setattr(signal, "alarm", lambda n: armed.append(n))
+        with _login_alarm(0):
+            pass
+        assert armed == []
 
 
 class TestLogout:


### PR DESCRIPTION
Fixes #16.

## Problem

`login()` failed on Windows before it ever reached the network:

```
AttributeError: module 'signal' has no attribute 'SIGALRM'
  336  original_handler = signal.signal(signal.SIGALRM, _timeout_handler)
```

`signal.SIGALRM` is Unix-only. The existing comment already said "Set timeout alarm (Unix only)" — the guard was just never written.

## Fix

Alarm setup/teardown moves into a `_login_alarm()` context manager and becomes best-effort. It is skipped when:

- `SIGALRM` is unavailable — **Windows**
- `signal.signal()` raises `ValueError` — `login()` called **off the main thread**, which fails on Linux and macOS too

That second case is a separate bug not mentioned in the issue: signal handlers can only be installed from the main thread, so calling `login()` from a thread pool or web request handler raised on every platform.

Timeouts remain enforced where the alarm is skipped:

- `_handle_verification()` already bounds its polling with `time.monotonic()` (cross-platform)
- `http.py` applies a 16s per-request timeout

The alarm was always a secondary guard, not the only one.

Using a context manager also guarantees the previous handler is restored, including when the login body raises — the arm and disarm can no longer drift out of sync.

## Verification

- `227 passed`, ruff clean
- Reproduced the exact reported `AttributeError` against the old code with `SIGALRM` deleted, and confirmed the same scenario now logs in successfully
- 4 new tests: simulated Windows (no `SIGALRM`), worker thread (`ValueError`), handler restored on exception, and `timeout=0` arming nothing

**Not tested on real Windows** — developed on macOS with `SIGALRM` removed to simulate it. That reproduces the reported failure precisely, but confirmation from the reporter would be worth having before considering this fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)