### PR TITLE
feat: add start_date to order history methods (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-09
+
+### Added
+- **`start_date` on order history** — avoid paging through years of orders to reach recent ones (re: [#15](https://github.com/jamestford/pyhood/issues/15))
+  - `get_stock_orders(start_date=...)`, `get_option_orders(start_date=...)`, `get_futures_orders(start_date=...)`, `get_filled_futures_orders(start_date=...)`
+  - Accepts a `datetime` or ISO-8601 string (`'2026-01-01'` or a full timestamp); naive values are treated as UTC
+  - Requested server-side via `created_at[gte]` so the API returns fewer pages, and re-applied client-side so an endpoint that ignores the filter still returns correctly filtered results
+  - Server-side filtering is confirmed working on options orders; stock and futures endpoints could not be verified against live data, hence the local fallback
+  - Omitting `start_date` preserves existing behaviour exactly — no param is sent
+  - 8 new tests (235 total)
+
 ## [0.8.1] - 2026-08-09
 
 ### Fixed

--- a/pyhood/__init__.py
+++ b/pyhood/__init__.py
@@ -1,6 +1,6 @@
 """pyhood — A modern, reliable Python client for the Robinhood API."""
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 from pyhood.auth import login, logout, refresh
 from pyhood.client import PyhoodClient

--- a/pyhood/client.py
+++ b/pyhood/client.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import re
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from pyhood import urls
@@ -1227,6 +1227,54 @@ class PyhoodClient:
             raise OrderError("No accounts found")
         return data[0].get("url", "")
 
+    @staticmethod
+    def _parse_start_date(start_date: str | datetime | None) -> datetime | None:
+        """Normalize a start_date into an aware UTC datetime.
+
+        Accepts a datetime or an ISO-8601 string ('2026-01-01' or a full
+        timestamp). Naive values are treated as UTC.
+        """
+        if start_date is None:
+            return None
+        if isinstance(start_date, datetime):
+            dt = start_date
+        else:
+            try:
+                dt = datetime.fromisoformat(str(start_date).replace("Z", "+00:00"))
+            except ValueError as e:
+                raise ValueError(
+                    f"start_date must be a datetime or ISO-8601 string, got {start_date!r}"
+                ) from e
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    @staticmethod
+    def _start_date_params(cutoff: datetime | None) -> dict[str, str] | None:
+        """Server-side filter params for an order-history cutoff."""
+        if cutoff is None:
+            return None
+        return {"created_at[gte]": cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")}
+
+    @staticmethod
+    def _before_cutoff(created_at: str, cutoff: datetime | None) -> bool:
+        """True if an order predates the cutoff and should be dropped.
+
+        Applied client-side as a safety net: not every orders endpoint is
+        confirmed to honour created_at[gte], and an ignored filter would
+        otherwise return silently unfiltered results. Unparseable timestamps
+        are kept rather than dropped.
+        """
+        if cutoff is None or not created_at:
+            return False
+        try:
+            dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt < cutoff
+
     def _related_symbols(
         self, entries: Any, symbol_cache: dict[str, str], resolve: bool = True
     ) -> list[str]:
@@ -1644,18 +1692,30 @@ class PyhoodClient:
             instrument_type="option",
         )
 
-    def get_stock_orders(self) -> list[Order]:
+    def get_stock_orders(self, start_date: str | datetime | None = None) -> list[Order]:
         """Get all stock orders (not options).
+
+        Args:
+            start_date: Only return orders created on or after this point.
+                Accepts a datetime or ISO-8601 string ('2026-01-01'); naive
+                values are treated as UTC. Filtering is requested server-side
+                to avoid paging through a long history, and re-applied locally.
 
         Returns:
             List of Order objects for stock orders.
         """
-        data = self._session.get_paginated(urls.ORDERS)
+        cutoff = self._parse_start_date(start_date)
+        data = self._session.get_paginated(
+            urls.ORDERS, params=self._start_date_params(cutoff),
+        )
         orders = []
 
         for item in data:
             # Skip option orders (they have legs)
             if "legs" in item or item.get("legs"):
+                continue
+
+            if self._before_cutoff(item.get("created_at", ""), cutoff):
                 continue
 
             created_at = None
@@ -1701,16 +1761,28 @@ class PyhoodClient:
 
         return orders
 
-    def get_option_orders(self) -> list[Order]:
+    def get_option_orders(self, start_date: str | datetime | None = None) -> list[Order]:
         """Get all option orders.
+
+        Args:
+            start_date: Only return orders created on or after this point.
+                Accepts a datetime or ISO-8601 string ('2026-01-01'); naive
+                values are treated as UTC. Filtering is requested server-side
+                to avoid paging through a long history, and re-applied locally.
 
         Returns:
             List of Order objects for option orders.
         """
-        data = self._session.get_paginated(urls.OPTIONS_ORDERS)
+        cutoff = self._parse_start_date(start_date)
+        data = self._session.get_paginated(
+            urls.OPTIONS_ORDERS, params=self._start_date_params(cutoff),
+        )
         orders = []
 
         for item in data:
+            if self._before_cutoff(item.get("created_at", ""), cutoff):
+                continue
+
             created_at = None
             filled_at = None
 
@@ -2058,6 +2130,7 @@ class PyhoodClient:
 
     def get_futures_orders(
         self, account_id: str | None = None,
+        start_date: str | datetime | None = None,
     ) -> list[FuturesOrder]:
         """Get all historical futures orders.
 
@@ -2066,10 +2139,16 @@ class PyhoodClient:
 
         Args:
             account_id: Futures account ID. Auto-discovered if None.
+            start_date: Only return orders created on or after this point.
+                Accepts a datetime or ISO-8601 string ('2026-01-01'); naive
+                values are treated as UTC. The futures service is not confirmed
+                to support server-side date filtering, so this may only filter
+                locally rather than reduce the number of pages fetched.
 
         Returns:
             List of FuturesOrder objects.
         """
+        cutoff = self._parse_start_date(start_date)
         if not account_id:
             account_id = self.get_futures_account_id()
 
@@ -2077,9 +2156,13 @@ class PyhoodClient:
         orders: list[FuturesOrder] = []
         url: str | None = urls.futures_orders_url(account_id)
 
+        params = self._start_date_params(cutoff)
         while url:
-            data = self._session.get(url)
+            data = self._session.get(url, params=params)
+            params = None  # Only sent on the first request; cursors carry it after
             for item in data.get("results", []):
+                if self._before_cutoff(item.get("created_at", ""), cutoff):
+                    continue
                 pnl = self._extract_futures_pnl(item)
                 orders.append(FuturesOrder(
                     order_id=item.get("id", ""),
@@ -2102,16 +2185,19 @@ class PyhoodClient:
 
     def get_filled_futures_orders(
         self, account_id: str | None = None,
+        start_date: str | datetime | None = None,
     ) -> list[FuturesOrder]:
         """Get only filled futures orders.
 
         Args:
             account_id: Futures account ID. Auto-discovered if None.
+            start_date: Only return orders created on or after this point.
+                See `get_futures_orders` for accepted formats.
 
         Returns:
             List of filled FuturesOrder objects.
         """
-        all_orders = self.get_futures_orders(account_id=account_id)
+        all_orders = self.get_futures_orders(account_id=account_id, start_date=start_date)
         return [o for o in all_orders if o.status == "filled"]
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["pyhood"]
 
 [project]
 name = "pyhood"
-version = "0.8.1"
+version = "0.9.0"
 description = "A modern, reliable Python client for the Robinhood API"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,7 @@
 """Tests for PyhoodClient — quotes, options, positions, earnings."""
 
+from datetime import datetime, timezone
+
 import pytest
 import responses
 
@@ -647,6 +649,113 @@ class TestStockOrders:
         assert order.price is None
         assert order.status == "filled"
         assert order.instrument_type == "stock"
+
+
+class TestOrderStartDate:
+    """start_date filtering on order history (#15)."""
+
+    ORDERS_PAYLOAD = {
+        "results": [
+            {
+                "id": "old-order",
+                "state": "filled",
+                "side": "buy",
+                "type": "market",
+                "quantity": "1",
+                "created_at": "2024-01-05T12:00:00Z",
+                "updated_at": "2024-01-05T12:00:00Z",
+            },
+            {
+                "id": "new-order",
+                "state": "filled",
+                "side": "buy",
+                "type": "market",
+                "quantity": "1",
+                "created_at": "2026-03-01T12:00:00Z",
+                "updated_at": "2026-03-01T12:00:00Z",
+            },
+        ],
+    }
+
+    @responses.activate
+    def test_start_date_sends_server_side_param(self, client):
+        """The cutoff is requested server-side so history isn't fully paged."""
+        responses.add(responses.GET, urls.ORDERS, json={"results": []}, status=200)
+
+        client.get_stock_orders(start_date="2026-01-01")
+
+        assert "created_at%5Bgte%5D=2026-01-01T00%3A00%3A00Z" in responses.calls[0].request.url
+
+    @responses.activate
+    def test_start_date_filters_locally_when_server_ignores_it(self, client):
+        """An ignored server-side filter must not yield unfiltered results."""
+        responses.add(responses.GET, urls.ORDERS, json=self.ORDERS_PAYLOAD, status=200)
+
+        orders = client.get_stock_orders(start_date="2026-01-01")
+
+        assert [o.order_id for o in orders] == ["new-order"]
+
+    @responses.activate
+    def test_option_orders_start_date(self, client):
+        responses.add(
+            responses.GET, urls.OPTIONS_ORDERS, json=self.ORDERS_PAYLOAD, status=200,
+        )
+
+        orders = client.get_option_orders(start_date="2026-01-01")
+
+        assert [o.order_id for o in orders] == ["new-order"]
+
+    @responses.activate
+    def test_no_start_date_returns_everything(self, client):
+        """Omitting start_date preserves the old behaviour and sends no param."""
+        responses.add(responses.GET, urls.ORDERS, json=self.ORDERS_PAYLOAD, status=200)
+
+        orders = client.get_stock_orders()
+
+        assert len(orders) == 2
+        assert "created_at" not in responses.calls[0].request.url
+
+    @responses.activate
+    def test_start_date_accepts_datetime(self, client):
+        responses.add(responses.GET, urls.ORDERS, json=self.ORDERS_PAYLOAD, status=200)
+
+        orders = client.get_stock_orders(start_date=datetime(2026, 1, 1))
+
+        assert [o.order_id for o in orders] == ["new-order"]
+
+    @responses.activate
+    def test_naive_and_aware_datetimes_agree(self, client):
+        """A naive cutoff is treated as UTC, matching the explicit-UTC form."""
+        responses.add(responses.GET, urls.ORDERS, json=self.ORDERS_PAYLOAD, status=200)
+        responses.add(responses.GET, urls.ORDERS, json=self.ORDERS_PAYLOAD, status=200)
+
+        naive = client.get_stock_orders(start_date=datetime(2026, 1, 1))
+        aware = client.get_stock_orders(
+            start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+        assert [o.order_id for o in naive] == [o.order_id for o in aware]
+
+    def test_invalid_start_date_raises(self, client):
+        with pytest.raises(ValueError, match="ISO-8601"):
+            client.get_stock_orders(start_date="last tuesday")
+
+    @responses.activate
+    def test_unparseable_created_at_is_kept(self, client):
+        """A malformed timestamp is kept rather than silently dropped."""
+        responses.add(
+            responses.GET,
+            urls.ORDERS,
+            json={"results": [{
+                "id": "weird-order", "state": "filled", "side": "buy",
+                "type": "market", "quantity": "1", "created_at": "not-a-date",
+            }]},
+            status=200,
+        )
+
+        orders = client.get_stock_orders(start_date="2026-01-01")
+
+        assert [o.order_id for o in orders] == ["weird-order"]
 
 
 class TestOptionOrders:


### PR DESCRIPTION
Closes #15.

## Problem

`get_option_orders()` pages through every order ever placed. For an account with a long options history that is very slow, as described in the linked robin_stocks [issue #507](https://github.com/jmfernandes/robin_stocks/issues/507).

## Change

`start_date` added to all four order-history methods:

- `get_stock_orders(start_date=...)`
- `get_option_orders(start_date=...)`
- `get_futures_orders(start_date=...)`
- `get_filled_futures_orders(start_date=...)`

Accepts a `datetime` or an ISO-8601 string (`'2026-01-01'` or a full timestamp). Naive values are treated as UTC. Omitting it sends no param and preserves existing behaviour exactly.

```python
orders = client.get_option_orders(start_date="2026-01-01")
orders = client.get_option_orders(start_date=datetime(2026, 1, 1, tzinfo=timezone.utc))
```

## Why filtering happens twice

The cutoff is sent server-side as `created_at[gte]` **and** re-applied client-side.

Probing the live API showed unknown query params are **silently ignored** rather than rejected — a deliberately bogus param returned the full unfiltered list. So on any endpoint that does not support `created_at[gte]`, a server-side-only implementation would return the entire history while appearing to work correctly. Silent wrong data is worse than a slow call.

Where the server honours the filter, the local pass is a no-op and the speedup is fully realised.

## Verification

`235 passed`, ruff clean. 8 new tests, including the server-ignores-the-filter case, naive/aware datetime agreement, invalid input raising `ValueError`, and malformed timestamps being kept rather than silently dropped.

Live-verified against the options endpoint:

| Call | Result |
| --- | --- |
| no `start_date` | 7 orders, 2024-12-26 → 12-30, 2.00s |
| `start_date="2024-12-28"` | 6 orders, earliest 2024-12-29 |
| `start_date="2026-01-01"` | 0 orders, 0.30s |

## Known limits

- Server-side filtering is **confirmed only on the options endpoint**. The test account has no stock orders and futures were not exercised, so for those the speedup is unproven — correctness is guaranteed by the local pass, but they may still page the full history.
- **Multi-page filtering is untested.** With only 7 orders there was never a `next` page, so it is unconfirmed that the filter survives pagination. `get_paginated` sends params on the first request only and relies on `next` URLs carrying the query — standard DRF behaviour, and the local filter covers correctness regardless.

An account with a long history would exercise both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)