### PR TITLE
chore: remove account identifiers from public files, slim sdist

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3,16 +3,20 @@
 ## Overview
 Modern Robinhood API client library. Public package on PyPI replacing abandoned robin_stocks.
 
+> **Note:** This file is public. Do not record account numbers, balances, tokens,
+> or any other account-identifying detail here.
+
 ## Repository & Distribution
 - **Repo:** github.com/jamestford/pyhood (public)
 - **PyPI:** pyhood package
-- **Local:** ~/Projects/pyhood
-- **Venv:** .venv (Python 3.14)
+- **Docs:** https://jamestford.github.io/pyhood
+- **Supported Python:** 3.10–3.13 (CI matrix); `requires-python = ">=3.10"`
 
 ## Authentication & Session
-- **Token Storage:** ~/.pyhood/session.json
+- **Token Storage:** `~/.pyhood/session.json` (override with `token_path`)
 - **Session Fields:** access_token, token_type, refresh_token, device_token, saved_at
-- **Account:** ~$16K balance, authenticated and working
+- **Session is per-process:** `get_session()` reads a module global, so a fresh
+  process must call `login()` or `refresh()` before constructing a client
 
 ## Key Features
 
@@ -22,6 +26,8 @@ Modern Robinhood API client library. Public package on PyPI replacing abandoned 
 - **Token Lifetime:** ~5-8 days (not 24h as commonly assumed)
 - **Auto-Recovery:** `login()` tries refresh first, falls back to full re-login
 - **Rate Limit Protection:** Aggressive safeguards against Robinhood's auth rate limits
+- **Cross-platform:** login timeout alarm is best-effort — skipped on Windows and
+  off the main thread, where `signal.SIGALRM` is unavailable
 
 ### Trading Features
 - Stocks/options quotes with Greeks
@@ -32,11 +38,13 @@ Modern Robinhood API client library. Public package on PyPI replacing abandoned 
 - Buying power and positions
 - Account information
 - Futures trading (contracts, quotes, orders, P&L)
+- Order history accepts `start_date` to avoid paging a full history
 
 ### Banking & Account Features
 - ACH bank account listing and management
 - ACH transfer history (deposits/withdrawals)
 - Initiate and cancel transfers
+- Debit card (Cash Management) transactions
 - Dividend history with symbol filtering
 - Watchlist management (list, add, remove)
 - Markets and trading hours lookup
@@ -61,7 +69,7 @@ Modern Robinhood API client library. Public package on PyPI replacing abandoned 
 - **Keys stored separately:** Crypto keys in pyhood config
 
 ## Testing & Quality
-- **Test Coverage:** ~79% (212 tests passing)
+- **Tests:** 235 passing
 - **CI Pipeline:** GitHub Actions on Python 3.10-3.13
 - **Linting:** ruff for code style
 - **HTTP Mocking:** responses library for reliable tests
@@ -72,15 +80,21 @@ Modern Robinhood API client library. Public package on PyPI replacing abandoned 
 - **Headers Matter:** Must use robin_stocks style headers (`Accept: */*`, `User-Agent: *`)
 - **NEVER retry without human confirmation** of device approval
 - **Refresh tokens work!** — Key differentiator from robin_stocks
+- **Tokens rotate on refresh:** refreshing invalidates the previous pair, so a
+  session copied to another machine is killed the next time either side refreshes
 
 ## IRA Support (v0.3.0)
-- **Roth IRA Account:** 915060792 (ira_roth, cash account, option_level_2)
-- **Individual Account:** 946351343 (margin)
 - **Discovery:** `get_all_accounts()` via bonfire `/accounts/unified/`
 - **IRA Positions:** Use `account_number` param for stocks, `account_numbers` (plural) for options
 - **IRA Orders:** Standard endpoints work with IRA account URL in payload
 - **Docs:** `docs/ira-api-notes.md` — full reverse-engineering notes
 - **Key gotcha:** `/accounts/` never shows IRA — must use bonfire or direct URL
+
+## API Quirks Worth Remembering
+- **Unknown query params are silently ignored**, not rejected — a filter the
+  endpoint does not support returns unfiltered data rather than an error
+- **News `related_instruments` are bare instrument IDs**, not symbols or dicts;
+  resolve via `/instruments/{id}/`
 
 ## Current Projects
 
@@ -91,7 +105,7 @@ Modern Robinhood API client library. Public package on PyPI replacing abandoned 
 
 ## API Architecture
 - `pyhood/auth.py` — Login, refresh, device approval
-- `pyhood/client.py` — Main HoodClient class
+- `pyhood/client.py` — Main `PyhoodClient` class
 - `pyhood/http.py` — Rate-limited HTTP with retries
 - `pyhood/models.py` — Typed dataclasses for all responses
 - `pyhood/exceptions.py` — Complete exception hierarchy
@@ -104,7 +118,3 @@ Modern Robinhood API client library. Public package on PyPI replacing abandoned 
 - Tokens rotate on refresh (old ones invalidated)
 - This enables automated systems to self-heal
 - robin_stocks never implemented this critical feature
-
-## Recent Fixes
-- **Linting:** All ruff failures resolved
-- **CI status:** All tests passing across Python 3.10-3.13

--- a/docs/ira-api-notes.md
+++ b/docs/ira-api-notes.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-23
 **Account:** Roth IRA (ira_roth)
-**Account Number:** 915060792
+**Account Number:** <IRA_ACCOUNT_NUMBER>
 **Status:** ✅ Fully working — stock and option orders confirmed
 
 ---
@@ -10,7 +10,7 @@
 ## 1. Discovery: Finding the IRA Account
 
 ### Problem
-The standard `/accounts/` endpoint only returns the individual margin account (946351343).
+The standard `/accounts/` endpoint only returns the individual margin account (<INDIVIDUAL_ACCOUNT_NUMBER>).
 The IRA account is **invisible** to `/accounts/` — no query parameter (`type`, `brokerage_account_type`, `all`, `include_retirement`, `page_size`, etc.) makes it appear.
 
 ### Solution
@@ -31,7 +31,7 @@ This returns a `results` array with **all** accounts (individual + IRA). Each en
 Once you know the account number, you can access it directly through the standard API:
 
 ```
-GET https://api.robinhood.com/accounts/915060792/
+GET https://api.robinhood.com/accounts/<IRA_ACCOUNT_NUMBER>/
 ```
 
 This returns the full account object (same schema as individual accounts), including:
@@ -47,7 +47,7 @@ This returns the full account object (same schema as individual accounts), inclu
 
 | Field | Value | Notes |
 |-------|-------|-------|
-| `account_number` | `915060792` | |
+| `account_number` | `<IRA_ACCOUNT_NUMBER>` | |
 | `type` | `cash` | No margin on IRA |
 | `brokerage_account_type` | `ira_roth` | |
 | `option_level` | `option_level_2` (max) | Level 3 capped to 2 |
@@ -73,7 +73,7 @@ By default, `option_level` is `null` (options not enabled).
 
 ### Enable via PATCH
 ```
-PATCH https://api.robinhood.com/accounts/915060792/
+PATCH https://api.robinhood.com/accounts/<IRA_ACCOUNT_NUMBER>/
 Content-Type: application/json
 
 {"option_level": "option_level_3"}
@@ -100,7 +100,7 @@ Standard `/orders/` endpoint works. Just use the IRA account URL:
 
 ```python
 payload = {
-    'account': 'https://api.robinhood.com/accounts/915060792/',
+    'account': 'https://api.robinhood.com/accounts/<IRA_ACCOUNT_NUMBER>/',
     'instrument': instrument_url,
     'symbol': 'AAPL',
     'type': 'limit',
@@ -126,7 +126,7 @@ Standard `/options/orders/` endpoint works with the IRA account URL:
 
 ```python
 payload = {
-    'account': 'https://api.robinhood.com/accounts/915060792/',
+    'account': 'https://api.robinhood.com/accounts/<IRA_ACCOUNT_NUMBER>/',
     'direction': 'debit',  # REQUIRED for options (not 'side')
     'legs': [{
         'position_effect': 'open',
@@ -157,7 +157,7 @@ r = session.post('https://api.robinhood.com/options/orders/', json=payload,
 - Use `direction` instead of `side` (unlike stock orders)
   - `"debit"` for buy orders
   - `"credit"` for sell orders (covered calls, CSPs)
-- The `account` field is the full URL: `https://api.robinhood.com/accounts/915060792/`
+- The `account` field is the full URL: `https://api.robinhood.com/accounts/<IRA_ACCOUNT_NUMBER>/`
 
 ---
 
@@ -165,27 +165,27 @@ r = session.post('https://api.robinhood.com/options/orders/', json=payload,
 
 ### Positions
 ```
-GET https://api.robinhood.com/positions/?account_number=915060792
+GET https://api.robinhood.com/positions/?account_number=<IRA_ACCOUNT_NUMBER>
 ```
 
 ### Option Positions
 ```
-GET https://api.robinhood.com/options/aggregate_positions/?account_numbers=915060792
+GET https://api.robinhood.com/options/aggregate_positions/?account_numbers=<IRA_ACCOUNT_NUMBER>
 ```
 
 ### Option Orders
 ```
-GET https://api.robinhood.com/options/orders/?account_numbers=915060792
+GET https://api.robinhood.com/options/orders/?account_numbers=<IRA_ACCOUNT_NUMBER>
 ```
 
 ### Portfolio
 ```
-GET https://api.robinhood.com/portfolios/915060792/
+GET https://api.robinhood.com/portfolios/<IRA_ACCOUNT_NUMBER>/
 ```
 
 All standard endpoints work with the IRA account number as a filter parameter.
 
-**Note:** `GET /accounts/915060792/positions/` returns 404. Use the query param approach.
+**Note:** `GET /accounts/<IRA_ACCOUNT_NUMBER>/positions/` returns 404. Use the query param approach.
 
 ---
 
@@ -194,14 +194,14 @@ All standard endpoints work with the IRA account number as a filter parameter.
 | Purpose | Endpoint | Method |
 |---------|----------|--------|
 | **Discover all accounts** | `GET bonfire.robinhood.com/accounts/unified/` | GET |
-| **IRA account details** | `GET api.robinhood.com/accounts/915060792/` | GET |
-| **Enable options** | `PATCH api.robinhood.com/accounts/915060792/` | PATCH |
-| **IRA portfolio** | `GET api.robinhood.com/portfolios/915060792/` | GET |
-| **IRA positions** | `GET api.robinhood.com/positions/?account_number=915060792` | GET |
-| **IRA option positions** | `GET api.robinhood.com/options/aggregate_positions/?account_numbers=915060792` | GET |
+| **IRA account details** | `GET api.robinhood.com/accounts/<IRA_ACCOUNT_NUMBER>/` | GET |
+| **Enable options** | `PATCH api.robinhood.com/accounts/<IRA_ACCOUNT_NUMBER>/` | PATCH |
+| **IRA portfolio** | `GET api.robinhood.com/portfolios/<IRA_ACCOUNT_NUMBER>/` | GET |
+| **IRA positions** | `GET api.robinhood.com/positions/?account_number=<IRA_ACCOUNT_NUMBER>` | GET |
+| **IRA option positions** | `GET api.robinhood.com/options/aggregate_positions/?account_numbers=<IRA_ACCOUNT_NUMBER>` | GET |
 | **Place stock order** | `POST api.robinhood.com/orders/` | POST (with account URL in body) |
 | **Place option order** | `POST api.robinhood.com/options/orders/` | POST (with account URL in body) |
-| **IRA option orders** | `GET api.robinhood.com/options/orders/?account_numbers=915060792` | GET |
+| **IRA option orders** | `GET api.robinhood.com/options/orders/?account_numbers=<IRA_ACCOUNT_NUMBER>` | GET |
 
 ---
 

--- a/pyhood/client.py
+++ b/pyhood/client.py
@@ -1111,7 +1111,7 @@ class PyhoodClient:
         in the legs data. Also fetches current market data for P&L and greeks.
 
         Args:
-            account_number: Filter to specific account (e.g. '915060792' for IRA).
+            account_number: Filter to a specific account, e.g. an IRA account number.
             nonzero: Only return positions with quantity > 0.
         """
         params: dict[str, str] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,19 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["pyhood"]
 
+[tool.hatch.build.targets.sdist]
+# Ship source, tests and the readable docs — not the multi-megabyte logo
+# sources, the built docs site config, or CI plumbing.
+include = [
+    "/pyhood",
+    "/tests",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/LICENSE",
+    "/SECURITY.md",
+    "/pyproject.toml",
+]
+
 [project]
 name = "pyhood"
 version = "0.9.0"


### PR DESCRIPTION
## Account identifiers removed from public files

Two real Robinhood account numbers were committed to files that are all publicly readable:

| Location | How it was exposed |
| --- | --- |
| `docs/ira-api-notes.md` (~20 occurrences) | repo **and** the deployed docs site |
| `STATUS.md` | repo, and every published sdist |
| `pyhood/client.py` docstring | **inside the wheel** — present in every install |

`STATUS.md` additionally recorded an account balance.

Both numbers are replaced with `<IRA_ACCOUNT_NUMBER>` / `<INDIVIDUAL_ACCOUNT_NUMBER>` placeholders, the balance line is gone, and `STATUS.md` now carries a note not to record account-identifying detail in a public file.

**This only stops further exposure.** The values remain in git history and in sdists already published to PyPI. Merging redeploys the docs site without them, which is the largest single improvement available without rewriting history.

## STATUS.md refresh

- `PyhoodClient`, not the nonexistent `HoodClient`
- Machine-specific checkout path and stale local venv version removed, replaced with the supported Python range
- Current test count
- Added API quirks learned while fixing #15/#16/#17: unknown query params are silently ignored rather than rejected, and news `related_instruments` are bare instrument IDs

## sdist slimmed 6.8 MB → 68 KB

The sdist shipped `assets/`, `docs/` and `.github/`, of which ~6.5 MB was logo sources (two files over 2 MB each). An explicit hatchling `include` list ships source, tests, README, changelog and licence only. The wheel is unaffected at 46 KB.

## Verification

- `235 passed`, ruff clean
- `twine check` passes both artifacts
- Extracted the built sdist and wheel and grepped for the account numbers and balance — absent, with a control string to confirm the scan actually ran against extracted files

🤖 Generated with [Claude Code](https://claude.com/claude-code)