### PR TITLE
docs: record packaging changes in 0.9.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Omitting `start_date` preserves existing behaviour exactly — no param is sent
   - 8 new tests (235 total)
 
+### Changed
+- **Source distribution reduced from 6.8 MB to 68 KB** — the sdist bundled `assets/`, `docs/` and `.github/`, of which ~6.5 MB was logo source images. It now ships source, tests, README, changelog and licence via an explicit include list. The wheel is unchanged at 46 KB.
+- Example account numbers in the IRA documentation and in the `get_positions()` docstring are now placeholders rather than literal values.
+
 ## [0.8.1] - 2026-08-09
 
 ### Fixed


### PR DESCRIPTION
The 0.9.0 changelog entry covered `start_date` but not the packaging work from #25. Adds a Changed section for the sdist size reduction and the docs/docstring placeholders, so the release notes match what actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)