### PR TITLE
chore: release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-09
+
 ### Fixed
 - **Futures contracts and quotes never worked** — `get_futures_contract()` raised `SymbolNotFound` for every valid symbol, and `get_futures_quote()` failed with it
   - The contract endpoint wraps its body in a `result` envelope with camelCase keys; the parser expected a flat snake_case object

--- a/pyhood/__init__.py
+++ b/pyhood/__init__.py
@@ -1,6 +1,6 @@
 """pyhood — A modern, reliable Python client for the Robinhood API."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 from pyhood.auth import login, logout, refresh
 from pyhood.client import PyhoodClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = [
 
 [project]
 name = "pyhood"
-version = "0.9.0"
+version = "0.10.0"
 description = "A modern, reliable Python client for the Robinhood API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump and changelog heading for 0.10.0.

Covers the futures repair (contracts and quotes never worked), IPO Access, `get_futures_positions()`, and `get_futures_quote_by_id()` / `get_futures_order_info()`.

Pre-flight: 259 passed, ruff clean, `twine check` passes both artifacts, and the built sdist and wheel scan clean for account identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)