### PR TITLE
chore: promote to Beta, broaden PyPI keywords, note excluded libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Promoted from `Development Status :: 3 - Alpha` to `4 - Beta` on PyPI — 259 tests, CI across Python 3.10-3.13, and ten releases
+- PyPI keywords now include `robinhood-api`, `robin_stocks`, `robin-stocks` and `pyrh`, so the package is findable by people searching for the libraries they are migrating from
+
 ## [0.10.0] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Against [robin_stocks](https://github.com/jmfernandes/robin_stocks) and its acti
 
 robin_stocks is the original and by far the most widely used — it earned that. But its last merge was February 2026, and its own issue tracker now [points newcomers to the fork](https://github.com/jmfernandes/robin_stocks/issues/1650). If you are migrating, pyhood is worth a look.
 
+**Also considered:** [pyrh](https://github.com/robinhood-unofficial/pyrh) (1.8k stars) — last release March 2023, last commit March 2024; [fast_arrow](https://github.com/westonplatter/fast_arrow) — options-focused, last commit 2021; [friartuck](https://github.com/codesociety/friartuck) — a backtesting framework rather than an API client, last commit 2023. The comparison above is limited to libraries under active development.
+
+For the API itself, [sanko/Robinhood](https://github.com/sanko/Robinhood) remains the best community reference for Robinhood's unofficial endpoints.
+
 *Verified against both repositories on 2026-08-09 by reading their source, not their docs. Corrections welcome — open an issue if anything here is out of date.*
 
 ## Why pyhood?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,21 @@ requires-python = ">=3.10"
 authors = [
     { name = "James Ford" },
 ]
-keywords = ["robinhood", "trading", "stocks", "options", "api"]
+keywords = [
+    "robinhood",
+    "robinhood-api",
+    "robin_stocks",
+    "robin-stocks",
+    "pyrh",
+    "trading",
+    "stocks",
+    "options",
+    "futures",
+    "crypto",
+    "api",
+]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Financial and Insurance Industry",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Two PyPI metadata changes.

**Alpha → Beta.** `Development Status :: 3 - Alpha` undersold the package — 259 tests, CI across Python 3.10-3.13, and ten releases. Alpha signals "not ready" to exactly the cautious evaluator who is comparing libraries.

**Keywords** now include `robinhood-api`, `robin_stocks`, `robin-stocks` and `pyrh` alongside the generic terms, plus `futures` and `crypto`. These are what people search when their current library stops working, which is the moment pyhood is most relevant to them.

Verified in the built wheel metadata:

```
Keywords: api,crypto,futures,options,pyrh,robin-stocks,robin_stocks,robinhood,robinhood-api,stocks,trading
Classifier: Development Status :: 4 - Beta
```

Note these only reach PyPI on the next release — the metadata for 0.10.0 is already published and immutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)