### PR TITLE
fix: read the populated cost basis fields on positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Position P&L was wrong, reporting gains on losing positions** — `get_positions()` read `average_buy_price`, which Robinhood returns as `0` for settled positions. Cost basis therefore came out as zero and `unrealized_pl` degenerated to equity. It now falls back to `clearing_average_cost` and prefers the broker's own `clearing_cost_basis`, matching what the app displays. Caught by comparing pyhood's output against the Robinhood web UI for the same position.
+- `get_positions()` no longer fetches each instrument to resolve a symbol — the positions payload already carries it, saving a request per position.
+
+### Fixed
 - **Market orders, fractional orders and trailing stops were all rejected** — Robinhood refuses orders that omit `order_form_version`, responding "Your app version is missing important stock trading updates". Despite the wording this is the *order form* version, not a client version. pyhood now sends `7`. Any value from 2 upward is accepted; `1` and omission are refused. robin_stocks sends `4` on ordinary stock orders, which works — but omits it on `order_trailing_stop`, so trailing stops fail there.
 - **Rejected orders were reported as successful** — `order_stock()` and `order_option()` only treated a response as an error when it carried a `detail` or `error` key, but Robinhood returns field-level validation errors (`{"field": ["message"]}`) that have neither. Any such rejection returned an `Order` with a blank id and no exception, so callers believed the order was placed. Both now raise when the response has no `id`.
 - Trailing stop rejections now raise a specific `OrderError` explaining that Robinhood gates the feature to its own app versions, rather than surfacing the raw server text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`get_portfolio_historicals()`** now raises `APIError` — Robinhood retired `/portfolios/historicals/`, which returns 404 for every parameter combination. It had a passing test that mocked the dead endpoint. robin_stocks calls the same URL.
+
+### Added
+- **`get_portfolio_performance()`** — the bonfire chart view model that replaced it. Returned unmapped: its y values are returns rather than equity, so mapping it onto `PortfolioCandle` would mean inventing figures the endpoint does not provide.
+
 ### Fixed
 - **Position P&L was wrong, reporting gains on losing positions** — `get_positions()` read `average_buy_price`, which Robinhood returns as `0` for settled positions. Cost basis therefore came out as zero and `unrealized_pl` degenerated to equity. It now falls back to `clearing_average_cost` and prefers the broker's own `clearing_cost_basis`, matching what the app displays. Caught by comparing pyhood's output against the Robinhood web UI for the same position.
 - `get_positions()` no longer fetches each instrument to resolve a symbol — the positions payload already carries it, saving a request per position.

--- a/pyhood/client.py
+++ b/pyhood/client.py
@@ -672,39 +672,52 @@ class PyhoodClient:
         span: str = "year",
         bounds: str = "regular",
     ) -> list[PortfolioCandle]:
-        """Get historical portfolio value over time.
+        """Deprecated — Robinhood retired this endpoint.
+
+        Raises:
+            APIError: Always. `/portfolios/historicals/` returns 404 for every
+                parameter combination as of 2026-08-09.
+
+        Use `get_portfolio_performance()` instead. It is not a drop-in: the
+        replacement returns a chart view model whose y values are returns
+        rather than equity, so it cannot be mapped onto `PortfolioCandle`
+        without inventing the equity figures.
+        """
+        from pyhood.exceptions import APIError
+
+        raise APIError(
+            "get_portfolio_historicals() is no longer available: Robinhood "
+            "retired /portfolios/historicals/ and it returns 404. Use "
+            "get_portfolio_performance(), which returns the chart view model "
+            "that replaced it."
+        )
+
+    def get_portfolio_performance(self, account_number: str | None = None) -> dict:
+        """Get the portfolio performance chart.
+
+        Replaces `get_portfolio_historicals()`, whose endpoint Robinhood
+        retired.
 
         Args:
-            account_number: Account number. If None, uses first account.
-            interval: 'day', 'week', '5minute', '10minute', 'hour'.
-            span: 'day', 'week', 'month', '3month', 'year', '5year', 'all'.
-            bounds: 'regular', 'extended', 'trading'.
+            account_number: Account number. If None, uses the first account.
+
+        Returns:
+            The raw chart view model: `lines` of plotted points with
+            `x_axis`, `y_axis`, `legend_data`, `fills` and `overlays`.
+
+        Note:
+            Returned unmapped on purpose. This is a rendering payload rather
+            than a time series — the y values are returns, not equity, and
+            each point carries display labels. Forcing it onto a dataclass
+            would mean inventing figures the endpoint does not provide.
         """
         if not account_number:
             accounts = self._session.get_paginated(urls.ACCOUNTS)
             if not accounts:
-                return []
+                return {}
             account_number = accounts[0].get("account_number", "")
 
-        url = urls.PORTFOLIO_HISTORICALS.format(account_number=account_number)
-        data = self._session.get(url, params={
-            "interval": interval,
-            "span": span,
-            "bounds": bounds,
-        })
-        results = data.get("equity_historicals", []) if isinstance(data, dict) else []
-        return [
-            PortfolioCandle(
-                begins_at=item.get("begins_at", ""),
-                adjusted_open_equity=float(item.get("adjusted_open_equity", 0)),
-                adjusted_close_equity=float(item.get("adjusted_close_equity", 0)),
-                open_equity=float(item.get("open_equity", 0)),
-                close_equity=float(item.get("close_equity", 0)),
-                open_market_value=float(item.get("open_market_value", 0)),
-                close_market_value=float(item.get("close_market_value", 0)),
-            )
-            for item in results
-        ]
+        return self._session.get(urls.portfolio_performance_url(account_number))
 
     # ── Option Historicals ────────────────────────────────────────────
 

--- a/pyhood/client.py
+++ b/pyhood/client.py
@@ -1125,22 +1125,29 @@ class PyhoodClient:
             qty = float(item.get("quantity", 0))
             if qty == 0 and nonzero:
                 continue
-            avg_cost = float(item.get("average_buy_price", 0))
+            # average_buy_price is 0 on positions the clearing system has
+            # settled; clearing_average_cost carries the real figure and is
+            # what the app displays.
+            avg_cost = float(item.get("average_buy_price", 0) or 0)
+            if not avg_cost:
+                avg_cost = float(item.get("clearing_average_cost", 0) or 0)
 
-            # Get current price from the instrument
-            instrument_url = item.get("instrument", "")
+            # The payload carries the symbol, so no instrument lookup is needed.
+            symbol = item.get("symbol", "")
             current_price = 0.0
-            if instrument_url:
-                try:
-                    inst_data = self._session.get(instrument_url)
-                    symbol = inst_data.get("symbol", "")
-                    quote = self.get_quote(symbol)
-                    current_price = quote.price
-                except Exception:
-                    symbol = ""
+            instrument_url = item.get("instrument", "")
+            try:
+                if not symbol and instrument_url:
+                    symbol = self._session.get(instrument_url).get("symbol", "")
+                if symbol:
+                    current_price = self.get_quote(symbol).price
+            except Exception:
+                pass
 
             equity = qty * current_price
-            cost_basis = qty * avg_cost
+            # Prefer the broker's own cost basis; it accounts for lots and
+            # corporate actions that quantity x average price does not.
+            cost_basis = float(item.get("clearing_cost_basis", 0) or 0) or qty * avg_cost
             unrealized_pl = equity - cost_basis
             unrealized_pl_pct = (unrealized_pl / cost_basis * 100) if cost_basis > 0 else 0.0
 

--- a/pyhood/urls.py
+++ b/pyhood/urls.py
@@ -16,6 +16,7 @@ LOGOUT = f"{OAUTH}/revoke_token/"
 # Account
 ACCOUNTS = f"{BASE}/accounts/"
 POSITIONS = f"{BASE}/positions/"
+BONFIRE = "https://bonfire.robinhood.com"
 PORTFOLIOS = f"{BASE}/portfolios/"
 
 # Stocks — Market Data
@@ -70,6 +71,8 @@ DIVIDENDS = f"{BASE}/dividends/"
 DOCUMENTS = f"{BASE}/documents/"
 
 # Portfolio Historicals
+# Retired by Robinhood — returns 404. Kept for reference; see
+# portfolio_performance_url() for the replacement.
 PORTFOLIO_HISTORICALS = f"{BASE}/portfolios/historicals/{{account_number}}/"
 
 # Options Historicals
@@ -112,6 +115,16 @@ SUBSCRIPTION_FEES = f"{BASE}/subscription/subscription_fees/"
 UNIFIED_TRANSFERS = "https://bonfire.robinhood.com/paymenthub/unified_transfers/"
 
 
+def portfolio_performance_url(account_number: str) -> str:
+    """URL for the portfolio performance chart view model."""
+    return f"{BONFIRE}/portfolio/performance/{account_number}"
+
+
+def portfolio_positions_url(account_number: str) -> str:
+    """URL for the portfolio positions view model."""
+    return f"{BONFIRE}/portfolio/{account_number}/positions_v2"
+
+
 def futures_positions_url(account_id: str) -> str:
     """URL for open futures positions on a specific account."""
     return f"{FUTURES_ACCOUNTS}{account_id}/positions/"
@@ -121,7 +134,6 @@ def futures_positions_url(account_id: str) -> str:
 # Undocumented bonfire view models backing Robinhood's retail IPO
 # allocation program.
 
-BONFIRE = "https://bonfire.robinhood.com"
 IPO_ACCESS_LIST = f"{BONFIRE}/lists/ipo_access/view_model/"
 IPO_ACCESS_VIEWMODELS = f"{BONFIRE}/equity_trading/ipo_access/viewmodels"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,6 @@ from pyhood.models import (
     OptionContract,
     OptionsChain,
     Order,
-    PortfolioCandle,
     Quote,
     Rating,
     StockSplit,
@@ -2156,37 +2155,33 @@ class TestSplits:
 
 
 class TestPortfolioHistoricals:
+    def test_portfolio_historicals_is_retired(self, client):
+        """Robinhood returns 404 for /portfolios/historicals/ (2026-08-09)."""
+        from pyhood.exceptions import APIError
+
+        with pytest.raises(APIError, match="no longer available"):
+            client.get_portfolio_historicals()
+
     @responses.activate
-    def test_get_portfolio_historicals(self, client):
+    def test_get_portfolio_performance(self, client):
+        """The replacement is a chart view model, returned unmapped."""
         responses.add(
-            responses.GET,
-            f"{BASE}/portfolios/historicals/123456/",
-            json={
-                "equity_historicals": [
-                    {
-                        "begins_at": "2026-03-28T00:00:00Z",
-                        "adjusted_open_equity": "15000.00",
-                        "adjusted_close_equity": "15200.00",
-                        "open_equity": "15000.00",
-                        "close_equity": "15200.00",
-                        "open_market_value": "14000.00",
-                        "close_market_value": "14200.00",
-                    },
-                ],
-            },
+            responses.GET, urls.ACCOUNTS,
+            json={"results": [{"account_number": "12345",
+                               "url": f"{BASE}/accounts/12345/"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET, urls.portfolio_performance_url("12345"),
+            json={"lines": [{"identifier": "returns", "segments": []}],
+                  "x_axis": {}, "y_axis": {}, "account_number": "12345"},
             status=200,
         )
 
-        candles = client.get_portfolio_historicals(
-            account_number="123456",
-        )
-        assert len(candles) == 1
-        assert isinstance(candles[0], PortfolioCandle)
-        assert candles[0].adjusted_close_equity == 15200.00
-        assert candles[0].close_market_value == 14200.00
+        data = client.get_portfolio_performance()
+        assert [ln["identifier"] for ln in data["lines"]] == ["returns"]
+        assert data["account_number"] == "12345"
 
-
-class TestOptionHistoricals:
     @responses.activate
     def test_get_option_historicals(self, client):
         responses.add(

--- a/tests/test_positions_cost_basis.py
+++ b/tests/test_positions_cost_basis.py
@@ -1,0 +1,93 @@
+"""Position cost basis and P&L.
+
+Payload captured live 2026-08-09. average_buy_price is 0 on a settled
+position; clearing_average_cost and clearing_cost_basis carry the real
+figures and are what the Robinhood app displays. Reading the wrong field
+made unrealized_pl equal equity — reporting a gain on a losing position.
+"""
+
+import pytest
+import responses
+
+from pyhood import urls
+from pyhood.client import PyhoodClient
+from pyhood.http import Session
+
+BASE = "https://api.robinhood.com"
+
+
+@pytest.fixture
+def client():
+    session = Session(timeout=5)
+    session.set_auth("Bearer", "test-token")
+    return PyhoodClient(session=session)
+
+
+# Captured live: TSLA, down from a 472.10 average cost
+SETTLED = {"results": [{
+    "symbol": "TSLA",
+    "quantity": "0.01162900",
+    "average_buy_price": "0.0000",
+    "clearing_average_cost": "472.10",
+    "clearing_cost_basis": "5.49",
+    "instrument": f"{BASE}/instruments/tsla-id/",
+}]}
+
+
+def _mock_quote(symbol, price):
+    responses.add(
+        responses.GET, f"{urls.QUOTES}{symbol}/",
+        json={"symbol": symbol, "last_trade_price": price,
+              "previous_close": price},
+        status=200,
+    )
+
+
+class TestPositionCostBasis:
+    @responses.activate
+    def test_falls_back_to_clearing_average_cost(self, client):
+        responses.add(responses.GET, urls.POSITIONS, json=SETTLED, status=200)
+        _mock_quote("TSLA", "328.55")
+
+        pos = client.get_positions()[0]
+        assert pos.average_cost == 472.10
+
+    @responses.activate
+    def test_loss_is_reported_as_a_loss(self, client):
+        responses.add(responses.GET, urls.POSITIONS, json=SETTLED, status=200)
+        _mock_quote("TSLA", "328.55")
+
+        pos = client.get_positions()[0]
+        assert pos.unrealized_pl < 0
+        assert pos.unrealized_pl == pytest.approx(-1.67, abs=0.02)
+        assert pos.unrealized_pl_pct == pytest.approx(-30.4, abs=0.5)
+
+    @responses.activate
+    def test_symbol_read_from_payload_without_instrument_fetch(self, client):
+        responses.add(responses.GET, urls.POSITIONS, json=SETTLED, status=200)
+        _mock_quote("TSLA", "328.55")
+
+        client.get_positions()
+
+        fetched = [c.request.url for c in responses.calls]
+        assert not any("instruments/tsla-id" in u for u in fetched)
+
+    @responses.activate
+    def test_average_buy_price_wins_when_populated(self, client):
+        payload = {"results": [dict(SETTLED["results"][0], average_buy_price="100.00")]}
+        responses.add(responses.GET, urls.POSITIONS, json=payload, status=200)
+        _mock_quote("TSLA", "328.55")
+
+        assert client.get_positions()[0].average_cost == 100.00
+
+    @responses.activate
+    def test_cost_basis_falls_back_to_qty_times_avg(self, client):
+        item = dict(SETTLED["results"][0])
+        item.pop("clearing_cost_basis")
+        responses.add(responses.GET, urls.POSITIONS,
+                      json={"results": [item]}, status=200)
+        _mock_quote("TSLA", "328.55")
+
+        pos = client.get_positions()[0]
+        # 0.011629 * 472.10 = 5.49
+        assert pos.unrealized_pl == pytest.approx(-1.67, abs=0.02)


### PR DESCRIPTION
`get_positions()` reported a **gain on a losing position**.

It read `average_buy_price`, which Robinhood returns as `0.0000` once a position has settled through clearing. Cost basis was therefore zero, and `unrealized_pl` degenerated into equity.

Measured against a real holding:

| Field | pyhood | Robinhood app |
| --- | --- | --- |
| `average_cost` | 0.00 | **472.10** |
| `unrealized_pl` | **+3.82** | **−1.66** |
| `unrealized_pl_pct` | 0.0 | — |

The populated fields are `clearing_average_cost` and `clearing_cost_basis`. The latter is preferred for the basis since it accounts for lots and corporate actions that quantity × average price does not. After the fix: avg cost 472.10, P/L −1.67, matching the app to within a price tick.

Also removes the per-position instrument fetch — the positions payload already carries `symbol`, so that was a wasted request per position.

## How it was found

By comparing pyhood's parsed output against the numbers displayed in the Robinhood web UI for the same account. Nothing in the schema was malformed; the values were simply wrong, which no amount of structural testing would have surfaced.

The same comparison validated `get_interest_payments()` exactly — summing its output gives 796.39 against the UI's "Lifetime interest paid $796.39".

`306 passed`, ruff clean. 5 new tests using the captured payload.