### PR TITLE
docs: explain how to obtain Crypto API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,8 @@ See the [account documentation](https://jamestford.github.io/pyhood/account/) fo
 ```python
 from pyhood.crypto import CryptoClient
 
-crypto = CryptoClient(
-    api_key="rh-api-...",
-    private_key_base64="...",
-)
+# Credentials are read from ~/.pyhood/crypto.env or the environment
+crypto = CryptoClient()
 
 quotes = crypto.get_best_bid_ask("BTC-USD", "ETH-USD")
 account = crypto.get_account()
@@ -228,7 +226,23 @@ order = crypto.place_order(
 )
 ```
 
-Generate API keys at [robinhood.com/account/crypto](https://robinhood.com/account/crypto). See the [crypto documentation](https://jamestford.github.io/pyhood/crypto/) for details.
+**Getting API keys.** Robinhood does not issue you a key pair — you generate one and register only the public half:
+
+```bash
+python -c "from pyhood.crypto.auth import generate_keypair; priv, pub = generate_keypair(); print('PRIVATE:', priv); print('PUBLIC :', pub)"
+```
+
+Paste the **public** key at [robinhood.com/account/crypto](https://robinhood.com/account/crypto) → API Trading → Add key. Robinhood then issues an **API key**. Save both:
+
+```
+# ~/.pyhood/crypto.env  (chmod 600)
+RH_CRYPTO_API_KEY=the-key-robinhood-issued
+RH_CRYPTO_PRIVATE_KEY=the-private-key-you-generated
+```
+
+The private key is the credential — anyone holding it can trade your crypto. Environment variables take precedence over this file, so a stale export will shadow it; `credentials_source()` reports which is in use.
+
+Only pairs with `api_tradable` set can be ordered through the API — a pair can be tradable in the app but not here. See the [crypto documentation](https://jamestford.github.io/pyhood/crypto/) for details.
 
 ### Futures
 


### PR DESCRIPTION
Rebuilt against the restructured README from #34 rather than merged — the original version was written before that rewrite and the prose it attached to no longer exists.

## What

The README says *"Generate API keys at robinhood.com/account/crypto"*, which skips the step that trips people up: **Robinhood does not issue you a key pair.** You generate an Ed25519 pair, register only the public half, and Robinhood issues an API key in return. Three values, two of which you create yourself.

Adds that flow to the Crypto Trading section, pointing at the `generate_keypair()` helper pyhood ships.

## Also updated

The example now constructs `CryptoClient()` with **no arguments**, which is how credentials resolve after #36 — the previous example passing `api_key=`/`private_key_base64=` inline is no longer the recommended shape.

Two notes added that cost real debugging time during verification:

- **Environment variables shadow `~/.pyhood/crypto.env`**, so a stale export silently overrides a correct file. `credentials_source()` reports which is in use.
- **Only pairs with `api_tradable` can be ordered through the API** — 58 of 89 on a live account. A pair can be tradable in the app but not here.

## Verified

Every claim checked against the live API: `generate_keypair()` returns a usable pair, `credentials_source()` reports `file`, `CryptoClient()` constructs and authenticates with no arguments, and `api_tradable` is populated.

Still draft: order placement is not yet confirmed end to end.