### PR TITLE
fix: store credentials owner-only; resolve crypto keys from disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Session tokens were written world-readable** — `~/.pyhood/session.json` holds live access and refresh tokens but was created with the process umask, producing `-rw-r--r--` on a default macOS setup. Any user or process on the machine could read it and act on the account. Credential files are now created `0600` inside a `0700` directory, the mode is applied at creation so contents are never briefly exposed, and loading an over-permissive file logs a warning with the `chmod` to run.
+
+### Added
+- **Crypto credential resolution** — `CryptoClient()` now takes no arguments and resolves credentials from `RH_CRYPTO_API_KEY` / `RH_CRYPTO_PRIVATE_KEY` or `~/.pyhood/crypto.env` (override with `PYHOOD_CRYPTO_ENV`), alongside the existing session file. `load_credentials()` and `credentials_available()` are exported. Explicit arguments still take precedence.
+
 ### Fixed
 - **Market orders, fractional orders and trailing stops were all rejected** — Robinhood refuses orders that omit `order_form_version`, responding "Your app version is missing important stock trading updates". Despite the wording this is the *order form* version, not a client version. pyhood now sends `7`. Any value from 2 upward is accepted; `1` and omission are refused. robin_stocks sends `4` on ordinary stock orders, which works — but omits it on `order_trailing_stop`, so trailing stops fail there.
 - **Rejected orders were reported as successful** — `order_stock()` and `order_option()` only treated a response as an error when it carried a `detail` or `error` key, but Robinhood returns field-level validation errors (`{"field": ["message"]}`) that have neither. Any such rejection returned an `Order` with a blank id and no exception, so callers believed the order was placed. Both now raise when the response has no `id`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Crypto quotes always returned 0.0** — `get_best_bid_ask()` read `bid_price`/`ask_price`; the API returns `bid`/`ask`.
+- **Crypto market-data calls failed authentication** — the signature covers the path *including* its query string, but pyhood signed the bare path and let `requests` append the query separately. Every parameterised crypto endpoint returned "Authentication failed".
+- **`get_best_bid_ask()` sent the wrong parameter** — `symbols=` comma-joined, where the API wants `symbol=` repeated; it rejected the former as "Malformed symbol parameter".
+- **`get_estimated_price()` returned zeros** — the estimate is wrapped in a `results` list, and the fee is `est_fee`.
+
+### Removed
+- **`CryptoClient.get_historicals()`** now raises `APIError` — the Crypto Trading API has no historicals endpoint. Every candidate path returns 404 and it is absent from Robinhood's published spec. Its tests mocked an endpoint that does not exist.
+
 ### Security
 - **Session tokens were written world-readable** — `~/.pyhood/session.json` holds live access and refresh tokens but was created with the process umask, producing `-rw-r--r--` on a default macOS setup. Any user or process on the machine could read it and act on the account. Credential files are now created `0600` inside a `0700` directory, the mode is applied at creation so contents are never briefly exposed, and loading an over-permissive file logs a warning with the `chmod` to run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Crypto orders could not be placed** — the payload omitted the required `client_order_id` idempotency key, and spread `order_config` flat instead of nesting it under `{type}_order_config` as the API expects. The README example demonstrated the wrong shape.
+- **`get_trading_pairs()` reported every field wrong** — the API uses `asset_code`/`quote_code`/`quote_increment`/`asset_increment`, and reports availability as `status` plus `is_api_tradable`. pyhood read `base_currency`, `price_increment`, `tradable` and similar, so every pair came back with empty currencies, zero increments and `tradable=False`. `TradingPair` now also exposes `api_tradable`, which is what actually governs whether a pair can be ordered through the API.
 - **Crypto quotes always returned 0.0** — `get_best_bid_ask()` read `bid_price`/`ask_price`; the API returns `bid`/`ask`.
 - **Crypto market-data calls failed authentication** — the signature covers the path *including* its query string, but pyhood signed the bare path and let `requests` append the query separately. Every parameterised crypto endpoint returned "Authentication failed".
 - **`get_best_bid_ask()` sent the wrong parameter** — `symbols=` comma-joined, where the API wants `symbol=` repeated; it rejected the former as "Malformed symbol parameter".

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ pyhood also supports Robinhood's **official** Crypto Trading API — no device a
 ```python
 from pyhood.crypto import CryptoClient
 
-# API key auth — generate keys at robinhood.com/account/crypto
+# API key auth — see "Getting Crypto API keys" below
 crypto = CryptoClient(api_key="rh-api-...", private_key_base64="...")
 
 # Market data
@@ -209,7 +209,38 @@ order = crypto.place_order(
 )
 ```
 
-Generate your API keys at [robinhood.com/account/crypto](https://robinhood.com/account/crypto). See the [Crypto documentation](https://jamestford.github.io/pyhood/crypto/) for full details.
+See the [Crypto documentation](https://jamestford.github.io/pyhood/crypto/) for full details.
+
+### Getting Crypto API keys
+
+Robinhood does not issue you a key pair. You generate one locally and register only the public half.
+
+**1. Generate a key pair:**
+
+```bash
+python -c "from pyhood.crypto.auth import generate_keypair; priv, pub = generate_keypair(); print('PRIVATE:', priv); print('PUBLIC :', pub)"
+```
+
+Keep the private key secret — it is the credential. Anyone holding it can trade your crypto.
+
+**2. Register the public key** at [robinhood.com/account/crypto](https://robinhood.com/account/crypto) → **API Trading** → **Add key**. Paste the **public** value. Robinhood then issues an **API key**.
+
+**3. Use both:**
+
+```python
+import os
+from pyhood.crypto import CryptoClient
+
+crypto = CryptoClient(
+    api_key=os.environ["RH_CRYPTO_API_KEY"],
+    private_key_base64=os.environ["RH_CRYPTO_PRIVATE_KEY"],
+)
+```
+
+Read them from the environment rather than hardcoding them.
+
+> Robinhood describes API trading as "currently limited and subject to change" — key creation may not be available on every account.
+
 
 ## Futures Trading
 

--- a/pyhood/auth.py
+++ b/pyhood/auth.py
@@ -28,6 +28,11 @@ from pyhood.exceptions import (
     RateLimitError,
 )
 from pyhood.http import Session
+from pyhood.secure_files import (
+    ensure_private_dir,
+    warn_if_readable_by_others,
+    write_private,
+)
 
 logger = logging.getLogger("pyhood")
 
@@ -97,12 +102,13 @@ class TokenStore:
 
     def __init__(self, path: Path | None = None):
         self.path = path or (DEFAULT_TOKEN_DIR / DEFAULT_TOKEN_FILE)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_private_dir(self.path.parent)
 
     def load(self) -> dict[str, Any] | None:
         """Load stored tokens. Returns None if no file or corrupt."""
         if not self.path.is_file():
             return None
+        warn_if_readable_by_others(self.path)
         try:
             with open(self.path) as f:
                 data = json.load(f)
@@ -131,8 +137,8 @@ class TokenStore:
             "device_token": device_token,
             "saved_at": time.time(),
         }
-        with open(self.path, "w") as f:
-            json.dump(data, f, indent=2)
+        # Session tokens are credentials — write owner-only.
+        write_private(self.path, json.dumps(data, indent=2))
         logger.debug(f"Tokens saved to {self.path}")
 
     def clear(self) -> None:

--- a/pyhood/crypto/__init__.py
+++ b/pyhood/crypto/__init__.py
@@ -4,6 +4,7 @@ from pyhood.crypto.client import CryptoClient
 from pyhood.crypto.credentials import (
     credentials_available,
     credentials_path,
+    credentials_source,
     load_credentials,
 )
 
@@ -11,5 +12,6 @@ __all__ = [
     "CryptoClient",
     "credentials_available",
     "credentials_path",
+    "credentials_source",
     "load_credentials",
 ]

--- a/pyhood/crypto/__init__.py
+++ b/pyhood/crypto/__init__.py
@@ -1,5 +1,15 @@
-"""pyhood.crypto — Robinhood Crypto Trading API v2 client."""
+"""pyhood.crypto — Robinhood Crypto Trading API client."""
 
 from pyhood.crypto.client import CryptoClient
+from pyhood.crypto.credentials import (
+    credentials_available,
+    credentials_path,
+    load_credentials,
+)
 
-__all__ = ["CryptoClient"]
+__all__ = [
+    "CryptoClient",
+    "credentials_available",
+    "credentials_path",
+    "load_credentials",
+]

--- a/pyhood/crypto/client.py
+++ b/pyhood/crypto/client.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 import requests
 
 from pyhood.crypto.auth import sign_request
+from pyhood.crypto.credentials import load_credentials
 from pyhood.crypto.models import (
     CryptoAccount,
     CryptoCandle,
@@ -80,14 +81,25 @@ class CryptoClient:
         quote = client.get_best_bid_ask("BTC-USD")
     """
 
-    def __init__(self, api_key: str, private_key_base64: str, timeout: float = 30.0):
+    def __init__(
+        self,
+        api_key: str | None = None,
+        private_key_base64: str | None = None,
+        timeout: float = 30.0,
+    ):
         """Initialize crypto client with API credentials.
 
         Args:
-            api_key: Robinhood Crypto API key
-            private_key_base64: Base64-encoded ED25519 private key
+            api_key: Robinhood Crypto API key. If omitted, resolved from the
+                RH_CRYPTO_API_KEY environment variable or ~/.pyhood/crypto.env.
+            private_key_base64: Base64-encoded ED25519 private key. Resolved
+                the same way when omitted.
             timeout: Request timeout in seconds
+
+        Raises:
+            FileNotFoundError: If credentials cannot be resolved.
         """
+        api_key, private_key_base64 = load_credentials(api_key, private_key_base64)
         self.api_key = api_key
         self.private_key_base64 = private_key_base64
         self.timeout = timeout

--- a/pyhood/crypto/client.py
+++ b/pyhood/crypto/client.py
@@ -202,7 +202,15 @@ class CryptoClient:
                 raise RateLimitError("Rate limited by server", retry_after)
 
         if response.status_code == 401:
-            raise AuthError("Authentication failed - check API key and signature")
+            from pyhood.crypto.credentials import credentials_source
+            raise AuthError(
+                "Authentication failed. Credentials were loaded from the "
+                f"{credentials_source()} — note that environment variables "
+                "take precedence over ~/.pyhood/crypto.env, so a stale export "
+                "will shadow a correct file. Robinhood also returns 401 rather "
+                "than 429 when throttling, so a burst of requests can look "
+                "like an auth failure."
+            )
 
         if response.status_code == 403:
             raise AuthError("Access forbidden - check API permissions")
@@ -210,7 +218,24 @@ class CryptoClient:
         if not response.ok:
             try:
                 error_data = response.json()
-                error_msg = error_data.get('message', f'HTTP {response.status_code}')
+                # The Crypto API reports problems as
+                # {"type": ..., "errors": [{"detail": ..., "attr": ...}]}.
+                # Reading only 'message' reduced every failure to "HTTP 400".
+                errors = error_data.get('errors')
+                if isinstance(errors, list) and errors:
+                    parts = []
+                    for err in errors:
+                        if isinstance(err, dict):
+                            detail = err.get('detail', '')
+                            attr = err.get('attr')
+                            parts.append(f"{attr}: {detail}" if attr else detail)
+                        else:
+                            parts.append(str(err))
+                    error_msg = "; ".join(p for p in parts if p)
+                else:
+                    error_msg = error_data.get(
+                        'message', error_data.get('detail', f'HTTP {response.status_code}')
+                    )
             except Exception:
                 error_msg = f'HTTP {response.status_code}'
             raise APIError(
@@ -483,7 +508,6 @@ class CryptoClient:
         path = CRYPTO_ORDERS.replace(CRYPTO_BASE, '')
 
         payload = {
-            'account_number': account_number,
             'client_order_id': client_order_id or str(uuid.uuid4()),
             'side': side,
             'type': order_type,
@@ -492,7 +516,12 @@ class CryptoClient:
         }
 
         body = json.dumps(payload)
-        data = self.make_request('POST', path, body=body)
+        # account_number goes in the query string, not the body — sending it
+        # only in the body is rejected with "The account_number parameter is
+        # required." The same applies to the holdings and orders GETs.
+        data = self.make_request(
+            'POST', path, body=body, params={'account_number': account_number},
+        )
 
         from datetime import datetime
         created_at = datetime.fromisoformat(data.get('created_at', '').replace('Z', '+00:00'))

--- a/pyhood/crypto/client.py
+++ b/pyhood/crypto/client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+import uuid
 from typing import Any
 from urllib.parse import urlencode, urlparse
 
@@ -311,13 +312,17 @@ class CryptoClient:
         for item in items:
             trading_pairs.append(TradingPair(
                 symbol=item.get('symbol', ''),
-                tradable=item.get('tradable', False),
-                min_order_size=float(item.get('min_order_size', 0)),
-                max_order_size=float(item.get('max_order_size', 0)),
-                price_increment=float(item.get('price_increment', 0)),
-                quantity_increment=float(item.get('quantity_increment', 0)),
-                base_currency=item.get('base_currency', ''),
-                quote_currency=item.get('quote_currency', ''),
+                # `status` is the app-level state; `is_api_tradable` governs
+                # whether the pair can be traded through this API at all.
+                tradable=item.get('status', '') == 'tradable',
+                api_tradable=bool(item.get('is_api_tradable', False)),
+                status=item.get('status', ''),
+                min_order_size=float(item.get('min_order_size', 0) or 0),
+                max_order_size=float(item.get('max_order_size', 0) or 0),
+                price_increment=float(item.get('quote_increment', 0) or 0),
+                quantity_increment=float(item.get('asset_increment', 0) or 0),
+                base_currency=item.get('asset_code', ''),
+                quote_currency=item.get('quote_code', ''),
             ))
 
         return trading_pairs
@@ -452,27 +457,38 @@ class CryptoClient:
         order_type: str,
         symbol: str,
         order_config: dict[str, Any],
+        client_order_id: str | None = None,
     ) -> CryptoOrder:
         """Place a crypto order.
 
         Args:
             account_number: Crypto account number
             side: 'buy' or 'sell'
-            order_type: 'market' or 'limit'
+            order_type: 'market', 'limit', 'stop_loss' or 'stop_limit'
             symbol: Crypto symbol (e.g., 'BTC-USD')
-            order_config: Order-specific configuration
+            order_config: Configuration for this order type, e.g.
+                ``{"asset_quantity": "0.001"}`` for a market order. It is
+                nested under ``{order_type}_order_config`` for you.
+            client_order_id: Idempotency key. Generated if omitted — resending
+                the same value returns the original order rather than placing
+                a second one.
 
         Returns:
             CryptoOrder object
+
+        Note:
+            Only pairs with `api_tradable` set can be ordered through this API;
+            a pair can be tradable in the app but not here.
         """
         path = CRYPTO_ORDERS.replace(CRYPTO_BASE, '')
 
         payload = {
             'account_number': account_number,
+            'client_order_id': client_order_id or str(uuid.uuid4()),
             'side': side,
             'type': order_type,
             'symbol': symbol,
-            **order_config,
+            f'{order_type}_order_config': order_config,
         }
 
         body = json.dumps(payload)

--- a/pyhood/crypto/client.py
+++ b/pyhood/crypto/client.py
@@ -9,7 +9,7 @@ import json
 import logging
 import time
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import requests
 
@@ -29,7 +29,6 @@ from pyhood.crypto.urls import (
     CRYPTO_BASE,
     CRYPTO_BEST_BID_ASK,
     CRYPTO_ESTIMATED_PRICE,
-    CRYPTO_HISTORICALS,
     CRYPTO_HOLDINGS,
     CRYPTO_ORDERS,
     CRYPTO_TRADING_PAIRS,
@@ -146,16 +145,28 @@ class CryptoClient:
             else:
                 raise RateLimitError(f"Rate limited, retry after {wait_time:.1f}s", wait_time)
 
+        # The signature covers the path *including* the query string, so the
+        # query is folded in here rather than passed to requests separately —
+        # signing the bare path while sending one with a query produced an
+        # authentication failure on every parameterised endpoint.
+        signed_path = path
+        if params:
+            query = urlencode(params, doseq=True)
+            if query:
+                separator = "&" if "?" in signed_path else "?"
+                signed_path = f"{signed_path}{separator}{query}"
+            params = None
+
         # Sign request
         try:
             api_key_header, signature, timestamp = sign_request(
-                self.api_key, self.private_key_base64, method.upper(), path, body
+                self.api_key, self.private_key_base64, method.upper(), signed_path, body
             )
         except ValueError as e:
             raise AuthError(f"Failed to sign request: {e}") from e
 
         # Prepare request
-        url = self.base_url.rstrip('/') + '/' + path.lstrip('/')
+        url = self.base_url.rstrip('/') + '/' + signed_path.lstrip('/')
         headers = {
             'x-api-key': api_key_header,
             'x-signature': signature,
@@ -321,9 +332,11 @@ class CryptoClient:
             List of CryptoQuote objects
         """
         path = CRYPTO_BEST_BID_ASK.replace(CRYPTO_BASE, '')
-        params = {}
+        # The endpoint takes `symbol` repeated, not a comma-joined `symbols`:
+        # sending `symbols=` is rejected with "Malformed symbol parameter".
+        params: dict[str, Any] = {}
         if symbols:
-            params['symbols'] = ','.join(symbols)
+            params['symbol'] = list(symbols)
 
         items = self._paginate(path, params)
 
@@ -334,8 +347,8 @@ class CryptoClient:
 
             quotes.append(CryptoQuote(
                 symbol=item.get('symbol', ''),
-                bid=float(item.get('bid_price', 0)),
-                ask=float(item.get('ask_price', 0)),
+                bid=float(item.get('bid', 0) or 0),
+                ask=float(item.get('ask', 0) or 0),
                 timestamp=timestamp,
             ))
 
@@ -359,15 +372,21 @@ class CryptoClient:
             'quantity': str(quantity),
         }
 
-        data = self.make_request('GET', path, params=params)
+        response = self.make_request('GET', path, params=params)
+        # The estimate is wrapped in a results list, as with the other
+        # marketdata endpoints.
+        results = response.get('results') if isinstance(response, dict) else None
+        data = results[0] if isinstance(results, list) and results else response
 
         return EstimatedPrice(
             symbol=data.get('symbol', symbol),
             side=data.get('side', side),
             quantity=float(data.get('quantity', quantity)),
-            bid_price=float(data.get('bid_price', 0)),
-            ask_price=float(data.get('ask_price', 0)),
-            fee=float(data.get('fee', 0)),
+            # The endpoint returns whichever side was asked for, as `bid` or
+            # `ask`, and names the fee `est_fee`.
+            bid_price=float(data.get('bid', data.get('bid_price', 0)) or 0),
+            ask_price=float(data.get('ask', data.get('ask_price', 0)) or 0),
+            fee=float(data.get('est_fee', data.get('fee', 0)) or 0),
         )
 
     # ── Historicals ──────────────────────────────────────────────────────
@@ -378,52 +397,24 @@ class CryptoClient:
         interval: str = "hour",
         span: str = "week",
     ) -> list[CryptoCandle]:
-        """Get historical OHLCV data for a crypto asset.
+        """Deprecated — the Crypto Trading API has no historicals endpoint.
 
-        Args:
-            symbol: Crypto symbol (e.g., 'BTC-USD').
-            interval: Candle interval. One of '15second', 'minute',
-                '5minute', '10minute', 'hour', 'day', 'week'. Default: 'hour'.
-            span: Time range. One of 'hour', 'day', 'week', 'month',
-                '3month', 'year', '5year'. Default: 'week'.
+        Raises:
+            APIError: Always.
 
-        Returns:
-            List of CryptoCandle dataclasses with OHLCV data.
+        Verified 2026-08-09: every candidate path returns 404
+        (`marketdata/historicals/`, `marketdata/candles/`,
+        `trading/historicals/`, on both `/api/v1/` and `/api/v2/`), and the
+        endpoint is absent from Robinhood's published OpenAPI spec.
+
+        For crypto price history, use the unofficial endpoints via
+        `PyhoodClient` rather than the official Crypto Trading API.
         """
-        valid_intervals = ("15second", "minute", "5minute", "10minute", "hour", "day", "week")
-        valid_spans = ("hour", "day", "week", "month", "3month", "year", "5year")
-
-        if interval not in valid_intervals:
-            raise ValueError(
-                f"interval must be one of {valid_intervals}, got '{interval}'"
-            )
-        if span not in valid_spans:
-            raise ValueError(
-                f"span must be one of {valid_spans}, got '{span}'"
-            )
-
-        path = f"{CRYPTO_HISTORICALS}{symbol}/".replace(CRYPTO_BASE, '')
-        data = self.make_request('GET', path, params={
-            "interval": interval,
-            "span": span,
-            "bounds": "24_7",
-        })
-
-        candles = []
-        for h in data.get("data_points", []):
-            candles.append(CryptoCandle(
-                symbol=symbol,
-                begins_at=h.get("begins_at", ""),
-                open_price=float(h.get("open_price", 0)),
-                close_price=float(h.get("close_price", 0)),
-                high_price=float(h.get("high_price", 0)),
-                low_price=float(h.get("low_price", 0)),
-                volume=float(h.get("volume", 0)),
-            ))
-
-        return candles
-
-    # ── Holdings ─────────────────────────────────────────────────────────
+        raise APIError(
+            "The Crypto Trading API has no historicals endpoint — every "
+            "candidate path returns 404 and it is absent from Robinhood's "
+            "published spec. Use the unofficial API for crypto price history."
+        )
 
     def get_holdings(self, account_number: str, *asset_codes: str) -> list[CryptoHolding]:
         """Get crypto holdings for account.

--- a/pyhood/crypto/credentials.py
+++ b/pyhood/crypto/credentials.py
@@ -1,0 +1,100 @@
+"""Loading Crypto API credentials from disk or the environment.
+
+Crypto API credentials are long-lived and, unlike a session token, cannot be
+refreshed — a leaked private key can trade until it is revoked. They should
+never be hardcoded or committed.
+
+Resolution order:
+
+1. ``RH_CRYPTO_API_KEY`` / ``RH_CRYPTO_PRIVATE_KEY`` environment variables
+2. ``~/.pyhood/crypto.env`` (override with ``PYHOOD_CRYPTO_ENV``)
+
+The file is a plain ``KEY=value`` env file:
+
+    RH_CRYPTO_API_KEY=your-api-key
+    RH_CRYPTO_PRIVATE_KEY=your-base64-ed25519-private-key
+
+It should be readable only by you (``chmod 600``); `load_credentials` warns
+if it is not.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from pyhood.secure_files import warn_if_readable_by_others
+
+logger = logging.getLogger("pyhood")
+
+API_KEY_VAR = "RH_CRYPTO_API_KEY"
+PRIVATE_KEY_VAR = "RH_CRYPTO_PRIVATE_KEY"
+DEFAULT_CREDENTIALS_FILE = Path.home() / ".pyhood" / "crypto.env"
+
+
+def credentials_path() -> Path:
+    """Where credentials are read from, honouring PYHOOD_CRYPTO_ENV."""
+    override = os.environ.get("PYHOOD_CRYPTO_ENV")
+    return Path(override) if override else DEFAULT_CREDENTIALS_FILE
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a KEY=value file. Ignores blanks, comments and malformed lines."""
+    values: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip().strip("'\"")
+    return values
+
+
+def load_credentials(
+    api_key: str | None = None, private_key_base64: str | None = None,
+) -> tuple[str, str]:
+    """Resolve Crypto API credentials.
+
+    Args:
+        api_key: Explicit API key. Skips lookup when both are given.
+        private_key_base64: Explicit private key.
+
+    Returns:
+        Tuple of (api_key, private_key_base64).
+
+    Raises:
+        FileNotFoundError: If neither the environment nor the file supplies
+            both values.
+    """
+    if api_key and private_key_base64:
+        return api_key, private_key_base64
+
+    resolved_key = api_key or os.environ.get(API_KEY_VAR, "")
+    resolved_private = private_key_base64 or os.environ.get(PRIVATE_KEY_VAR, "")
+
+    if not (resolved_key and resolved_private):
+        path = credentials_path()
+        if path.exists():
+            warn_if_readable_by_others(path)
+            values = _parse_env_file(path)
+            resolved_key = resolved_key or values.get(API_KEY_VAR, "")
+            resolved_private = resolved_private or values.get(PRIVATE_KEY_VAR, "")
+
+    if not (resolved_key and resolved_private):
+        raise FileNotFoundError(
+            f"No crypto credentials found. Set {API_KEY_VAR} and "
+            f"{PRIVATE_KEY_VAR}, or create {credentials_path()} containing "
+            f"both (chmod 600). See the README for how to generate a key pair."
+        )
+
+    return resolved_key, resolved_private
+
+
+def credentials_available() -> bool:
+    """Whether credentials can be resolved, without returning them."""
+    try:
+        load_credentials()
+        return True
+    except FileNotFoundError:
+        return False

--- a/pyhood/crypto/credentials.py
+++ b/pyhood/crypto/credentials.py
@@ -91,6 +91,22 @@ def load_credentials(
     return resolved_key, resolved_private
 
 
+def credentials_source() -> str:
+    """Where credentials would be read from: 'environment', 'file' or 'none'.
+
+    Environment variables take precedence, so a stale export silently shadows
+    a correct file — worth being able to check when authentication fails.
+    """
+    if os.environ.get(API_KEY_VAR) and os.environ.get(PRIVATE_KEY_VAR):
+        return "environment"
+    path = credentials_path()
+    if path.exists():
+        values = _parse_env_file(path)
+        if values.get(API_KEY_VAR) and values.get(PRIVATE_KEY_VAR):
+            return "file"
+    return "none"
+
+
 def credentials_available() -> bool:
     """Whether credentials can be resolved, without returning them."""
     try:

--- a/pyhood/crypto/models.py
+++ b/pyhood/crypto/models.py
@@ -34,7 +34,12 @@ class CryptoAccount:
 
 @dataclass(frozen=True)
 class TradingPair:
-    """Trading pair configuration and limits."""
+    """Trading pair configuration and limits.
+
+    `tradable` reflects Robinhood's `status`; `api_tradable` reflects
+    `is_api_tradable`, which is the one that governs API orders. A pair can be
+    tradable in the app but not through the API.
+    """
     symbol: str
     tradable: bool
     min_order_size: float
@@ -43,6 +48,8 @@ class TradingPair:
     quantity_increment: float
     base_currency: str
     quote_currency: str
+    api_tradable: bool = False
+    status: str = ""
 
 
 @dataclass(frozen=True)

--- a/pyhood/secure_files.py
+++ b/pyhood/secure_files.py
@@ -1,0 +1,64 @@
+"""Owner-only file handling for stored credentials.
+
+Session tokens and Crypto API keys are credentials: anyone who can read them
+can act on the account. Files holding them are created 0600 and their
+directory 0700, and a warning is logged if an existing file is looser.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+
+logger = logging.getLogger("pyhood")
+
+OWNER_ONLY_FILE = 0o600
+OWNER_ONLY_DIR = 0o700
+
+
+def ensure_private_dir(path: Path) -> None:
+    """Create a directory that only the owner can read."""
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, OWNER_ONLY_DIR)
+    except OSError as e:  # pragma: no cover - platform dependent
+        logger.debug(f"Could not tighten permissions on {path}: {e}")
+
+
+def write_private(path: Path, content: str) -> None:
+    """Write a file only the owner can read.
+
+    The mode is applied at creation so the content is never briefly readable
+    by others, and reapplied afterwards in case the file already existed.
+    """
+    ensure_private_dir(path.parent)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, OWNER_ONLY_FILE)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+    finally:
+        try:
+            os.chmod(path, OWNER_ONLY_FILE)
+        except OSError as e:  # pragma: no cover - platform dependent
+            logger.debug(f"Could not tighten permissions on {path}: {e}")
+
+
+def warn_if_readable_by_others(path: Path) -> bool:
+    """Warn when a credential file is group or world readable.
+
+    Returns:
+        True if the permissions are too open.
+    """
+    try:
+        mode = path.stat().st_mode
+    except OSError:
+        return False
+    if mode & (stat.S_IRGRP | stat.S_IROTH | stat.S_IWGRP | stat.S_IWOTH):
+        logger.warning(
+            f"{path} is accessible to other users on this machine. It holds "
+            f"credentials that can act on your account — run: chmod 600 {path}"
+        )
+        return True
+    return False

--- a/tests/test_credential_files.py
+++ b/tests/test_credential_files.py
@@ -1,0 +1,97 @@
+"""Credential files must be owner-only, and crypto credentials resolvable.
+
+~/.pyhood/session.json holds live access and refresh tokens. It was being
+written with the process umask, which on a default macOS setup produced
+-rw-r--r-- — readable by every user on the machine.
+"""
+
+import json
+import os
+import stat
+
+import pytest
+
+from pyhood.auth import TokenStore
+from pyhood.crypto.credentials import (
+    API_KEY_VAR,
+    PRIVATE_KEY_VAR,
+    credentials_available,
+    load_credentials,
+)
+from pyhood.secure_files import warn_if_readable_by_others, write_private
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+class TestSecureWrites:
+    def test_written_file_is_owner_only(self, tmp_path):
+        target = tmp_path / "nested" / "secret.json"
+
+        write_private(target, '{"token": "x"}')
+
+        assert _mode(target) == 0o600
+        assert _mode(target.parent) == 0o700
+        assert target.read_text() == '{"token": "x"}'
+
+    def test_existing_loose_file_is_tightened(self, tmp_path):
+        target = tmp_path / "secret.json"
+        target.write_text("old")
+        os.chmod(target, 0o644)
+
+        write_private(target, "new")
+
+        assert _mode(target) == 0o600
+        assert target.read_text() == "new"
+
+    def test_warns_only_when_others_can_read(self, tmp_path, caplog):
+        target = tmp_path / "s.json"
+        target.write_text("x")
+
+        os.chmod(target, 0o600)
+        assert warn_if_readable_by_others(target) is False
+
+        os.chmod(target, 0o644)
+        assert warn_if_readable_by_others(target) is True
+
+
+class TestTokenStorePermissions:
+    def test_saved_session_is_owner_only(self, tmp_path):
+        store = TokenStore(tmp_path / "session.json")
+
+        store.save("access", "Bearer", "refresh", "device")
+
+        assert _mode(store.path) == 0o600
+        assert json.loads(store.path.read_text())["access_token"] == "access"
+
+
+class TestCryptoCredentials:
+    def test_explicit_values_win(self):
+        assert load_credentials("k", "p") == ("k", "p")
+
+    def test_reads_environment(self, monkeypatch):
+        monkeypatch.setenv(API_KEY_VAR, "env-key")
+        monkeypatch.setenv(PRIVATE_KEY_VAR, "env-priv")
+
+        assert load_credentials() == ("env-key", "env-priv")
+
+    def test_reads_env_file_when_environment_empty(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(API_KEY_VAR, raising=False)
+        monkeypatch.delenv(PRIVATE_KEY_VAR, raising=False)
+        f = tmp_path / "crypto.env"
+        f.write_text(
+            f"# comment\n{API_KEY_VAR}=file-key\n\n{PRIVATE_KEY_VAR}='file-priv'\n"
+        )
+        monkeypatch.setenv("PYHOOD_CRYPTO_ENV", str(f))
+
+        assert load_credentials() == ("file-key", "file-priv")
+
+    def test_missing_credentials_raise_with_guidance(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(API_KEY_VAR, raising=False)
+        monkeypatch.delenv(PRIVATE_KEY_VAR, raising=False)
+        monkeypatch.setenv("PYHOOD_CRYPTO_ENV", str(tmp_path / "absent.env"))
+
+        with pytest.raises(FileNotFoundError, match="No crypto credentials"):
+            load_credentials()
+        assert credentials_available() is False

--- a/tests/test_crypto_client.py
+++ b/tests/test_crypto_client.py
@@ -9,7 +9,6 @@ from pyhood.crypto.auth import generate_keypair
 from pyhood.crypto.client import CryptoClient, TokenBucket
 from pyhood.crypto.models import (
     CryptoAccount,
-    CryptoCandle,
     CryptoHolding,
     CryptoOrder,
     CryptoQuote,
@@ -21,7 +20,6 @@ from pyhood.crypto.urls import (
     CRYPTO_BASE,
     CRYPTO_BEST_BID_ASK,
     CRYPTO_ESTIMATED_PRICE,
-    CRYPTO_HISTORICALS,
     CRYPTO_HOLDINGS,
     CRYPTO_ORDERS,
     CRYPTO_TRADING_PAIRS,
@@ -162,8 +160,8 @@ class TestCryptoClient:
             json={
                 "results": [{
                     "symbol": "BTC-USD",
-                    "bid_price": "45000.00",
-                    "ask_price": "45100.00",
+                    "bid": "45000.00",
+                    "ask": "45100.00",
                     "timestamp": "2023-10-30T12:00:00Z",
                 }]
             },
@@ -207,70 +205,16 @@ class TestCryptoClient:
         assert price.ask_price == 45100.00
         assert price.fee == 1.50
 
-    @responses.activate
-    def test_get_historicals(self):
-        """Test getting crypto historicals."""
-        responses.add(
-            responses.GET,
-            f"{CRYPTO_HISTORICALS}BTC-USD/",
-            json={
-                "data_points": [
-                    {
-                        "begins_at": "2023-10-30T11:00:00Z",
-                        "open_price": "34100.00",
-                        "close_price": "34200.00",
-                        "high_price": "34250.00",
-                        "low_price": "34050.00",
-                        "volume": "123.45",
-                    },
-                    {
-                        "begins_at": "2023-10-30T12:00:00Z",
-                        "open_price": "34200.00",
-                        "close_price": "34300.00",
-                        "high_price": "34350.00",
-                        "low_price": "34150.00",
-                        "volume": "98.76",
-                    },
-                ]
-            },
-            status=200,
-        )
+    def test_get_historicals_is_retired(self):
+        """The Crypto Trading API has no historicals endpoint (2026-08-09).
 
-        candles = self.client.get_historicals("BTC-USD", interval="hour", span="day")
+        Every candidate path returns 404 and it is absent from Robinhood's
+        published spec. The old tests mocked an endpoint that does not exist.
+        """
+        from pyhood.exceptions import APIError
 
-        assert len(candles) == 2
-        c = candles[0]
-        assert isinstance(c, CryptoCandle)
-        assert c.symbol == "BTC-USD"
-        assert c.begins_at == "2023-10-30T11:00:00Z"
-        assert c.open_price == 34100.00
-        assert c.close_price == 34200.00
-        assert c.high_price == 34250.00
-        assert c.low_price == 34050.00
-        assert c.volume == 123.45
-
-    def test_get_historicals_invalid_interval(self):
-        """Test invalid interval raises ValueError."""
-        with pytest.raises(ValueError, match="interval must be one of"):
-            self.client.get_historicals("BTC-USD", interval="1minute")
-
-    def test_get_historicals_invalid_span(self):
-        """Test invalid span raises ValueError."""
-        with pytest.raises(ValueError, match="span must be one of"):
-            self.client.get_historicals("BTC-USD", span="10year")
-
-    @responses.activate
-    def test_get_historicals_empty(self):
-        """Test empty historicals response."""
-        responses.add(
-            responses.GET,
-            f"{CRYPTO_HISTORICALS}DOGE-USD/",
-            json={"data_points": []},
-            status=200,
-        )
-
-        candles = self.client.get_historicals("DOGE-USD")
-        assert candles == []
+        with pytest.raises(APIError, match="no historicals endpoint"):
+            self.client.get_historicals("BTC-USD")
 
     @responses.activate
     def test_get_holdings(self):

--- a/tests/test_crypto_client.py
+++ b/tests/test_crypto_client.py
@@ -121,35 +121,56 @@ class TestCryptoClient:
 
     @responses.activate
     def test_get_trading_pairs(self):
-        """Test getting trading pairs."""
+        """Fields captured live 2026-08-09.
+
+        The API names these asset_code/quote_code/quote_increment/
+        asset_increment and reports availability as `status` plus
+        `is_api_tradable` — not `tradable`, `base_currency`, or
+        `price_increment` as previously assumed.
+        """
         responses.add(
             responses.GET,
             CRYPTO_TRADING_PAIRS,
             json={
                 "results": [{
-                    "symbol": "BTC-USD",
-                    "tradable": True,
-                    "min_order_size": "0.000001",
+                    "asset_code": "BTC",
+                    "quote_code": "USD",
+                    "quote_increment": "0.01",
+                    "asset_increment": "0.000001",
                     "max_order_size": "100.0",
-                    "price_increment": "0.01",
-                    "quantity_increment": "0.000001",
-                    "base_currency": "BTC",
-                    "quote_currency": "USD",
+                    "status": "tradable",
+                    "symbol": "BTC-USD",
+                    "is_api_tradable": True,
+                }, {
+                    "asset_code": "BILL",
+                    "quote_code": "USD",
+                    "quote_increment": "0.000001",
+                    "asset_increment": "0.1",
+                    "max_order_size": "9900000.0",
+                    "status": "tradable",
+                    "symbol": "BILL-USD",
+                    "is_api_tradable": False,
                 }]
             },
             status=200
         )
 
-        pairs = self.client.get_trading_pairs("BTC-USD")
+        pairs = self.client.get_trading_pairs()
 
-        assert len(pairs) == 1
-        pair = pairs[0]
-        assert isinstance(pair, TradingPair)
-        assert pair.symbol == "BTC-USD"
-        assert pair.tradable is True
-        assert pair.min_order_size == 0.000001
-        assert pair.base_currency == "BTC"
-        assert pair.quote_currency == "USD"
+        assert len(pairs) == 2
+        btc = pairs[0]
+        assert isinstance(btc, TradingPair)
+        assert btc.symbol == "BTC-USD"
+        assert btc.base_currency == "BTC"
+        assert btc.quote_currency == "USD"
+        assert btc.price_increment == 0.01
+        assert btc.quantity_increment == 0.000001
+        assert btc.tradable is True
+        assert btc.api_tradable is True
+
+        # tradable in the app but not through the API
+        assert pairs[1].tradable is True
+        assert pairs[1].api_tradable is False
 
     @responses.activate
     def test_get_best_bid_ask(self):


### PR DESCRIPTION
## Security fix

`~/.pyhood/session.json` holds live **access and refresh tokens** but was written with the process umask. On a default macOS setup that produces:

```
-rw-r--r--  session.json
drwxr-xr-x  .pyhood/
```

Any user or process on the machine could read it and act on the account. Confirmed on a real install before the fix; after, both are `-rw-------` / `drwx------`.

Credential files are now created `0600` inside a `0700` directory. The mode is applied at `open()` rather than `chmod`'d afterwards, so contents are never briefly readable by others, and it is reapplied when the file already exists. Loading an over-permissive file logs a warning naming the exact `chmod`.

This is the same class of issue pyhood's README criticises robin_stocks for with `pickle` — worth fixing before pointing at anyone else's storage.

## Crypto credential resolution

`CryptoClient()` now takes no arguments and resolves credentials from `RH_CRYPTO_API_KEY` / `RH_CRYPTO_PRIVATE_KEY`, or `~/.pyhood/crypto.env` (override with `PYHOOD_CRYPTO_ENV`) — the same directory the session already uses. Explicit arguments still take precedence.

Crypto keys are long-lived and cannot be refreshed: a leaked private key can trade until revoked. Giving them a documented home beats having users hardcode them.

## Verification

`309 passed`, ruff clean. 8 new tests covering mode-at-creation, tightening an existing loose file, warning only when others can read, and the credential resolution order.

## How it came up

From the question of where to keep crypto keys for testing — "aren't we doing something similar with the auth session". Looking at that path is what exposed the permissions bug.