### PR TITLE
fix: parse crypto orders from the fields the API actually returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Crypto orders parsed almost every field wrong** — the API reports `state`, `filled_asset_quantity`, `average_price` and `fee_charged`, and keeps the requested size and price inside `{type}_order_config`. pyhood read `status`, `quantity`, `price`, `filled_quantity`, `average_filled_price` and `fee` at the top level, so a real order came back with an empty status, zero quantity and no price. The three construction sites are now one `_parse_order()` helper, which also stops the old code raising `ValueError` when a timestamp is absent.
+- **`place_order()` sent `account_number` in the body** — the API requires it as a query parameter and rejects the body form with "The account_number parameter is required". Notably it is absent from `OrderRequest` in Robinhood's published spec.
+
 ### Removed
 - **`get_portfolio_historicals()`** now raises `APIError` — Robinhood retired `/portfolios/historicals/`, which returns 404 for every parameter combination. It had a passing test that mocked the dead endpoint. robin_stocks calls the same URL.
 

--- a/README.md
+++ b/README.md
@@ -211,10 +211,8 @@ See the [account documentation](https://jamestford.github.io/pyhood/account/) fo
 ```python
 from pyhood.crypto import CryptoClient
 
-crypto = CryptoClient(
-    api_key="rh-api-...",
-    private_key_base64="...",
-)
+# Credentials are read from ~/.pyhood/crypto.env or the environment
+crypto = CryptoClient()
 
 quotes = crypto.get_best_bid_ask("BTC-USD", "ETH-USD")
 account = crypto.get_account()
@@ -228,7 +226,23 @@ order = crypto.place_order(
 )
 ```
 
-Generate API keys at [robinhood.com/account/crypto](https://robinhood.com/account/crypto). See the [crypto documentation](https://jamestford.github.io/pyhood/crypto/) for details.
+**Getting API keys.** Robinhood does not issue you a key pair — you generate one and register only the public half:
+
+```bash
+python -c "from pyhood.crypto.auth import generate_keypair; priv, pub = generate_keypair(); print('PRIVATE:', priv); print('PUBLIC :', pub)"
+```
+
+Paste the **public** key at [robinhood.com/account/crypto](https://robinhood.com/account/crypto) → API Trading → Add key. Robinhood then issues an **API key**. Save both:
+
+```
+# ~/.pyhood/crypto.env  (chmod 600)
+RH_CRYPTO_API_KEY=the-key-robinhood-issued
+RH_CRYPTO_PRIVATE_KEY=the-private-key-you-generated
+```
+
+The private key is the credential — anyone holding it can trade your crypto. Environment variables take precedence over this file, so a stale export will shadow it; `credentials_source()` reports which is in use.
+
+Only pairs with `api_tradable` set can be ordered through the API — a pair can be tradable in the app but not here. See the [crypto documentation](https://jamestford.github.io/pyhood/crypto/) for details.
 
 ### Futures
 

--- a/pyhood/crypto/client.py
+++ b/pyhood/crypto/client.py
@@ -9,6 +9,7 @@ import json
 import logging
 import time
 import uuid
+from datetime import datetime
 from typing import Any
 from urllib.parse import urlencode, urlparse
 
@@ -475,6 +476,53 @@ class CryptoClient:
 
     # ── Orders ───────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _parse_order(data: dict[str, Any]) -> CryptoOrder:
+        """Build a CryptoOrder from an API order payload.
+
+        Field names captured live 2026-08-09. The API uses `state`,
+        `filled_asset_quantity`, `average_price` and `fee_charged`, and keeps
+        the requested size and price inside `{type}_order_config` rather than
+        at the top level. Reading `status`, `quantity` or `price` directly
+        yields empty values on a real order.
+        """
+        def _dt(value):
+            if not value:
+                return None
+            try:
+                return datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+            except ValueError:
+                return None
+
+        order_type = data.get('type', '')
+        config = data.get(f'{order_type}_order_config') or {}
+        quantity = float(config.get('asset_quantity', 0) or 0)
+        filled = float(data.get('filled_asset_quantity', 0) or 0)
+        limit_price = config.get('limit_price')
+
+        return CryptoOrder(
+            order_id=data.get('id', ''),
+            client_order_id=data.get('client_order_id'),
+            side=data.get('side', ''),
+            order_type=order_type,
+            symbol=data.get('symbol', ''),
+            status=data.get('state', ''),
+            price=float(limit_price) if limit_price is not None else None,
+            quantity=quantity,
+            filled_quantity=filled,
+            remaining_quantity=max(quantity - filled, 0.0),
+            average_filled_price=(
+                float(data['average_price'])
+                if data.get('average_price') is not None else None
+            ),
+            fee=(
+                float(data['fee_charged'])
+                if data.get('fee_charged') is not None else None
+            ),
+            created_at=_dt(data.get('created_at')),
+            updated_at=_dt(data.get('updated_at')),
+        )
+
     def place_order(
         self,
         account_number: str,
@@ -523,29 +571,8 @@ class CryptoClient:
             'POST', path, body=body, params={'account_number': account_number},
         )
 
-        from datetime import datetime
-        created_at = datetime.fromisoformat(data.get('created_at', '').replace('Z', '+00:00'))
-        updated_at = datetime.fromisoformat(data.get('updated_at', '').replace('Z', '+00:00'))
 
-        return CryptoOrder(
-            order_id=data.get('id', ''),
-            client_order_id=data.get('client_order_id'),
-            side=data.get('side', side),
-            order_type=data.get('type', order_type),
-            symbol=data.get('symbol', symbol),
-            status=data.get('status', ''),
-            price=float(data['price']) if data.get('price') is not None else None,
-            quantity=float(data.get('quantity', 0)),
-            filled_quantity=float(data.get('filled_quantity', 0)),
-            remaining_quantity=float(data.get('remaining_quantity', 0)),
-            average_filled_price=(
-                float(data['average_filled_price'])
-                if data.get('average_filled_price') is not None else None
-            ),
-            fee=float(data['fee']) if data.get('fee') is not None else None,
-            created_at=created_at,
-            updated_at=updated_at,
-        )
+        return self._parse_order(data)
 
     def get_order(self, account_number: str, order_id: str) -> CryptoOrder:
         """Get a specific crypto order.
@@ -562,29 +589,8 @@ class CryptoClient:
 
         data = self.make_request('GET', path, params=params)
 
-        from datetime import datetime
-        created_at = datetime.fromisoformat(data.get('created_at', '').replace('Z', '+00:00'))
-        updated_at = datetime.fromisoformat(data.get('updated_at', '').replace('Z', '+00:00'))
 
-        return CryptoOrder(
-            order_id=data.get('id', order_id),
-            client_order_id=data.get('client_order_id'),
-            side=data.get('side', ''),
-            order_type=data.get('type', ''),
-            symbol=data.get('symbol', ''),
-            status=data.get('status', ''),
-            price=float(data['price']) if data.get('price') is not None else None,
-            quantity=float(data.get('quantity', 0)),
-            filled_quantity=float(data.get('filled_quantity', 0)),
-            remaining_quantity=float(data.get('remaining_quantity', 0)),
-            average_filled_price=(
-                float(data['average_filled_price'])
-                if data.get('average_filled_price') is not None else None
-            ),
-            fee=float(data['fee']) if data.get('fee') is not None else None,
-            created_at=created_at,
-            updated_at=updated_at,
-        )
+        return self._parse_order(data)
 
     def get_orders(self, account_number: str) -> list[CryptoOrder]:
         """Get all crypto orders for account.
@@ -602,29 +608,8 @@ class CryptoClient:
 
         orders = []
         for item in items:
-            from datetime import datetime
-            created_at = datetime.fromisoformat(item.get('created_at', '').replace('Z', '+00:00'))
-            updated_at = datetime.fromisoformat(item.get('updated_at', '').replace('Z', '+00:00'))
 
-            orders.append(CryptoOrder(
-                order_id=item.get('id', ''),
-                client_order_id=item.get('client_order_id'),
-                side=item.get('side', ''),
-                order_type=item.get('type', ''),
-                symbol=item.get('symbol', ''),
-                status=item.get('status', ''),
-                price=float(item['price']) if item.get('price') is not None else None,
-                quantity=float(item.get('quantity', 0)),
-                filled_quantity=float(item.get('filled_quantity', 0)),
-                remaining_quantity=float(item.get('remaining_quantity', 0)),
-                average_filled_price=(
-                    float(item['average_filled_price'])
-                    if item.get('average_filled_price') is not None else None
-                ),
-                fee=float(item['fee']) if item.get('fee') is not None else None,
-                created_at=created_at,
-                updated_at=updated_at,
-            ))
+            orders.append(self._parse_order(item))
 
         return orders
 

--- a/tests/test_crypto_client.py
+++ b/tests/test_crypto_client.py
@@ -1,5 +1,6 @@
 """Tests for crypto client module."""
 
+import json
 from datetime import datetime
 
 import pytest
@@ -264,25 +265,32 @@ class TestCryptoClient:
 
     @responses.activate
     def test_place_order(self):
-        """Test placing a crypto order."""
+        """Payload and response shape captured live 2026-08-09.
+
+        The API reports `state`, `filled_asset_quantity`, `average_price` and
+        `fee_charged`, and keeps size and price inside `{type}_order_config`.
+        """
         responses.add(
             responses.POST,
             CRYPTO_ORDERS,
             json={
-                "id": "order-123",
+                "symbol": "BTC-USD",
                 "client_order_id": "client-123",
                 "side": "buy",
-                "type": "market",
-                "symbol": "BTC-USD",
-                "status": "pending",
-                "price": None,
-                "quantity": "0.001",
-                "filled_quantity": "0.0",
-                "remaining_quantity": "0.001",
-                "average_filled_price": None,
-                "fee": None,
-                "created_at": "2023-10-30T12:00:00Z",
-                "updated_at": "2023-10-30T12:00:00Z",
+                "type": "limit",
+                "id": "order-123",
+                "account_number": "12345",
+                "state": "open",
+                "filled_asset_quantity": "0.000000000000000000",
+                "executions": [],
+                "average_price": None,
+                "created_at": "2026-08-09T16:42:33.494640-04:00",
+                "updated_at": "2026-08-09T16:42:34.198331-04:00",
+                "fee_charged": 0.0,
+                "limit_order_config": {
+                    "asset_quantity": "0.000100000000000000",
+                    "limit_price": "32548.380000000000000000",
+                },
             },
             status=200
         )
@@ -290,55 +298,61 @@ class TestCryptoClient:
         order = self.client.place_order(
             account_number="12345",
             side="buy",
-            order_type="market",
+            order_type="limit",
             symbol="BTC-USD",
-            order_config={"quantity": "0.001"}
+            order_config={"asset_quantity": "0.0001", "limit_price": "32548.38"},
         )
 
         assert isinstance(order, CryptoOrder)
         assert order.order_id == "order-123"
-        assert order.client_order_id == "client-123"
-        assert order.side == "buy"
-        assert order.order_type == "market"
-        assert order.symbol == "BTC-USD"
-        assert order.status == "pending"
-        assert order.price is None
-        assert order.quantity == 0.001
+        assert order.status == "open"
+        assert order.quantity == 0.0001
+        assert order.price == 32548.38
+        assert order.filled_quantity == 0.0
+        assert order.remaining_quantity == 0.0001
+        assert order.fee == 0.0
+        assert order.average_filled_price is None
+
+        # account_number belongs in the query string, not the body
+        request = responses.calls[-1].request
+        assert "account_number=12345" in request.url
+        body = json.loads(request.body)
+        assert "account_number" not in body
+        assert body["limit_order_config"] == {
+            "asset_quantity": "0.0001", "limit_price": "32548.38",
+        }
+        assert body["client_order_id"]
 
     @responses.activate
     def test_get_order(self):
-        """Test getting a specific order."""
+        """A cancelled order reports state, not status."""
         responses.add(
             responses.GET,
             f"{CRYPTO_ORDERS}order-123/",
             json={
-                "id": "order-123",
+                "symbol": "BTC-USD",
                 "client_order_id": "client-123",
                 "side": "buy",
                 "type": "limit",
-                "symbol": "BTC-USD",
-                "status": "filled",
-                "price": "45000.00",
-                "quantity": "0.001",
-                "filled_quantity": "0.001",
-                "remaining_quantity": "0.0",
-                "average_filled_price": "45000.00",
-                "fee": "1.50",
-                "created_at": "2023-10-30T12:00:00Z",
-                "updated_at": "2023-10-30T12:05:00Z",
+                "id": "order-123",
+                "state": "canceled",
+                "filled_asset_quantity": "0.0",
+                "average_price": None,
+                "fee_charged": 0.0,
+                "created_at": "2026-08-09T16:42:33.494640-04:00",
+                "updated_at": "2026-08-09T16:43:47.340423-04:00",
+                "limit_order_config": {
+                    "asset_quantity": "0.0001", "limit_price": "32548.38",
+                },
             },
             status=200
         )
 
         order = self.client.get_order("12345", "order-123")
 
-        assert isinstance(order, CryptoOrder)
         assert order.order_id == "order-123"
-        assert order.status == "filled"
-        assert order.price == 45000.00
-        assert order.average_filled_price == 45000.00
-        assert order.fee == 1.50
-
+        assert order.status == "canceled"
+        assert order.price == 32548.38
     @responses.activate
     def test_get_orders(self):
         """Test getting all orders."""


### PR DESCRIPTION
Placing and cancelling two real orders exposed that `CryptoOrder` misreads almost every field.

| pyhood read | API returns |
| --- | --- |
| `status` | `state` |
| `quantity` | `{type}_order_config.asset_quantity` |
| `price` | `{type}_order_config.limit_price` |
| `filled_quantity` | `filled_asset_quantity` |
| `average_filled_price` | `average_price` |
| `fee` | `fee_charged` |

A live cancelled order returned `status=''`, `quantity=0.0`, `price=None` — I had to read the raw payload to confirm the cancellation had worked, which is exactly what the typed model exists to avoid.

The three construction sites are now one `_parse_order()` helper. It also tolerates a missing timestamp: the previous code called `datetime.fromisoformat` on an empty string, which raises rather than returning `None`.

Also folds in the `place_order` fix — `account_number` must be a **query parameter**; sending it in the body is rejected with *"The account_number parameter is required."* It is absent from `OrderRequest` in Robinhood's published spec, so the spec is wrong here too.

## Verified

Against two real orders placed and cancelled on a live account:

```
6a78e639  status='canceled'  qty=0.0001  price=32548.38  filled=0.0  fee=0.0
6a78e5c3  status='canceled'  qty=0.0001  price=32549.24  filled=0.0  fee=0.0
```

`312 passed`, ruff clean. The order tests now use the captured payload instead of an invented one, and assert the query-string/body split.