### PR TITLE
feat: guided credential setup via `python -m pyhood setup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to pyhood will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`python -m pyhood setup`** — guided credential setup, replacing the copy-paste snippets in the README
+  - `setup login` establishes a session. The stored session is tried first, so a valid or refreshable one needs no password at all; only when that fails does it prompt, handling MFA and device approval.
+  - `setup crypto` generates an Ed25519 key pair, shows only the public half for registration, reads the API key Robinhood issues, writes both owner-only, and then makes one signed read-only call to confirm the pair is accepted. That last step is the point: writing a file proves nothing, and without it a mistyped or placeholder key is not discovered until a real request fails with an authentication error that reads like a service outage.
+  - `setup` with no target reports what is configured — which source credentials resolve from, file permissions, and whether the private key is a real Ed25519 key. No network calls, and lengths and validity only, never values.
+  - Secrets are read with `getpass` and there are deliberately no `--password` or `--api-key` options, since arguments are visible to other processes via `ps` and are recorded by the shell. The crypto private key goes from generation directly to disk and is never displayed.
+  - Existing crypto credentials are not replaced without `--force` — overwriting would orphan a key that still works.
+  - Available programmatically as `pyhood.onboarding.crypto_status()`, `session_status()` and `print_status()`.
+
+### Changed
+- The README's key-generation snippet printed the private key to the terminal, where it lands in scrollback. It now points at `python -m pyhood setup crypto`, with the manual file format kept as a fallback.
+- Quick Start no longer opens with a hardcoded password — it uses the stored session.
+
+### Fixed
+- The README's portfolio example still called `get_portfolio_historicals()`, which raises `APIError` as of 0.11.0. It now shows `get_portfolio_performance()`.
+
 ## [0.11.0] - 2026-08-09
 
 A repair release. Every fix below was found by running pyhood against the live Robinhood API. Each broken feature shipped with passing tests that mocked a response shape the API never returns, so CI stayed green while the feature was unusable.

--- a/README.md
+++ b/README.md
@@ -24,18 +24,26 @@ pyhood is a modern, typed, maintained Python client for Robinhood. It supports s
 pip install pyhood
 ```
 
+Then set up credentials. The setup commands prompt for secrets interactively — nothing sensitive is passed as an argument, since command-line arguments are visible to other processes and recorded in shell history.
+
+```bash
+python -m pyhood setup login    # session tokens for stocks, options, futures
+python -m pyhood setup crypto   # key pair for the Crypto Trading API
+python -m pyhood setup          # report what is configured
+```
+
+Both write to `~/.pyhood/`, readable only by you. See [Setup](#setup) for what each one does.
+
 ## Quick Start
+
+Once `python -m pyhood setup login` has stored a session, no credentials appear in your code at all:
 
 ```python
 import pyhood
 from pyhood.client import PyhoodClient
 
-# First login may require device approval in the Robinhood mobile app.
-session = pyhood.login(
-    username="you@email.com",
-    password="your_password",
-    timeout=90,
-)
+# Reuses the stored session, refreshing it if the access token has expired.
+session = pyhood.login()
 
 client = PyhoodClient(session)
 
@@ -46,13 +54,10 @@ positions = client.get_positions()
 buying_power = client.get_buying_power()
 ```
 
-After the first approved login, pyhood can refresh the session without credentials:
+`login()` with no arguments tries the cached session, then the refresh token. To force a refresh explicitly:
 
 ```python
-import pyhood
-
 session = pyhood.refresh()
-client = PyhoodClient(session)
 ```
 
 ## Why pyhood exists
@@ -102,16 +107,47 @@ Against [robin_stocks](https://github.com/jmfernandes/robin_stocks) and the acti
 
 Migrating from `robin_stocks`? See the [migration guide](docs/migrating-from-robin-stocks.md) for a function-by-function map.
 
+## Setup
+
+pyhood uses two unrelated kinds of credential, and `python -m pyhood setup` configures either one.
+
+| Command | Credential | Stored at |
+|---|---|---|
+| `python -m pyhood setup login` | Session tokens for the main API — stocks, options, futures | `~/.pyhood/session.json` |
+| `python -m pyhood setup crypto` | Ed25519 key pair for the Crypto Trading API | `~/.pyhood/crypto.env` |
+| `python -m pyhood setup` | — | reports what is configured |
+
+Both files are created `0600` inside a `0700` directory, with the mode applied at creation so the contents are never briefly readable by others.
+
+**`setup login`** tries the stored session first — a valid or refreshable one needs no password at all. Only when that fails does it prompt for your username and password, handling MFA and device approval. The password is read without echoing and is never stored; only the resulting tokens are written.
+
+**`setup crypto`** generates an Ed25519 key pair on your machine, prints only the public half for you to register with Robinhood, then reads the API key Robinhood issues and writes both to disk. The private key goes straight from generation to file — it is never displayed. Afterwards it makes one signed read-only call to confirm Robinhood actually accepts the pair, which is the step that catches a mistyped or placeholder key immediately rather than at your first order.
+
+**`setup`** with no target reports what is configured — where credentials came from, file permissions, and whether the private key is a real Ed25519 key. It shows lengths and validity, never values, and makes no network calls.
+
+```
+$ python -m pyhood setup
+Session (main API — stocks, options, futures)
+    /Users/you/.pyhood/session.json (refreshable, saved 1.2h ago)
+
+Crypto API (official Crypto Trading API)
+    source: file
+    /Users/you/.pyhood/crypto.env
+    api key: 43 chars
+    private key: valid Ed25519, 32 bytes
+```
+
+Secrets are only ever read interactively. There are deliberately no `--password` or `--api-key` options: arguments are visible to every process on the machine via `ps` and are recorded by your shell.
+
 ## Authentication
 
 Robinhood requires device approval on first login. After that, pyhood keeps the session alive automatically.
 
 ### First Login
 
-1. Open the Robinhood mobile app.
-2. Call `pyhood.login()`.
-3. Approve the device prompt in the app.
-4. pyhood saves the session to `~/.pyhood/session.json`.
+Run `python -m pyhood setup login` and approve the device prompt in the Robinhood mobile app when it appears. The session is saved to `~/.pyhood/session.json`.
+
+To log in from code instead:
 
 ```python
 import pyhood
@@ -122,6 +158,8 @@ session = pyhood.login(
     timeout=90,
 )
 ```
+
+Prefer the setup command where you can — a password written into a script tends to end up committed.
 
 ### Staying Authenticated
 
@@ -226,13 +264,15 @@ order = crypto.place_order(
 )
 ```
 
-**Getting API keys.** Robinhood does not issue you a key pair — you generate one and register only the public half:
+**Getting API keys.** Robinhood does not issue you a key pair — you generate one and register only the public half. The setup command walks through it:
 
 ```bash
-python -c "from pyhood.crypto.auth import generate_keypair; priv, pub = generate_keypair(); print('PRIVATE:', priv); print('PUBLIC :', pub)"
+python -m pyhood setup crypto
 ```
 
-Paste the **public** key at [robinhood.com/account/crypto](https://robinhood.com/account/crypto) → API Trading → Add key. Robinhood then issues an **API key**. Save both:
+It generates the key pair, shows you the **public** key to paste at [robinhood.com/account/crypto](https://robinhood.com/account/crypto) → API Trading → Add key, reads the **API key** Robinhood issues back, writes both to `~/.pyhood/crypto.env` at mode `0600`, and then makes one signed read-only call to confirm the pair works. The private key is never displayed.
+
+If you would rather do it by hand, the file is a plain env file:
 
 ```
 # ~/.pyhood/crypto.env  (chmod 600)
@@ -240,7 +280,7 @@ RH_CRYPTO_API_KEY=the-key-robinhood-issued
 RH_CRYPTO_PRIVATE_KEY=the-private-key-you-generated
 ```
 
-The private key is the credential — anyone holding it can trade your crypto. Environment variables take precedence over this file, so a stale export will shadow it; `credentials_source()` reports which is in use.
+The private key is the credential — anyone holding it can trade your crypto, and unlike a session token it cannot be refreshed, only revoked. Environment variables take precedence over this file, so a stale export will silently shadow it; `python -m pyhood setup` reports which source is in use.
 
 Only pairs with `api_tradable` set can be ordered through the API — a pair can be tradable in the app but not here. See the [crypto documentation](https://jamestford.github.io/pyhood/crypto/) for details.
 
@@ -259,14 +299,12 @@ See the [futures documentation](https://jamestford.github.io/pyhood/futures/) fo
 ### Portfolio and Documents
 
 ```python
-history = client.get_portfolio_historicals(
-    account_number="123456",
-    interval="day",
-    span="year",
-)
+performance = client.get_portfolio_performance()
 
 docs = client.get_documents(doc_type="account_statement")
 ```
+
+`get_portfolio_historicals()` raises `APIError` — Robinhood retired that endpoint. `get_portfolio_performance()` returns the chart view model that replaced it, unmapped, since its y values are returns rather than equity.
 
 ## Feature Status
 
@@ -283,7 +321,8 @@ docs = client.get_documents(doc_type="account_statement")
 | Watchlists | Functional |
 | Markets and trading hours | Functional |
 | Research, news, ratings, movers, and popularity | Functional |
-| Portfolio and option historicals | Functional |
+| Option historicals and portfolio performance | Functional |
+| Guided credential setup (`python -m pyhood setup`) | Functional |
 | Documents and statements | Functional |
 | Day trades, margin calls, and deposit schedules | Functional |
 

--- a/docs/api/onboarding.md
+++ b/docs/api/onboarding.md
@@ -1,0 +1,15 @@
+# Setup
+
+The functions behind `python -m pyhood setup`. See [Setup](../setup.md) for the command-line walkthrough.
+
+None of the status functions return a secret value, and none of them make network calls.
+
+::: pyhood.onboarding.print_status
+
+::: pyhood.onboarding.session_status
+
+::: pyhood.onboarding.crypto_status
+
+::: pyhood.onboarding.setup_login
+
+::: pyhood.onboarding.setup_crypto

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -8,6 +8,14 @@ pyhood handles Robinhood's OAuth2 authentication with three layers of session ma
 
 When you call `pyhood.login()`, it tries each layer in order, falling back only when necessary.
 
+The quickest way to establish a session is the setup command, which drives the same three layers and prompts only for what it actually needs:
+
+```bash
+python -m pyhood setup login
+```
+
+See [Setup](setup.md) for what it prompts for and how the tokens are stored.
+
 ## Login Flow
 
 ```python

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -14,37 +14,30 @@ pyhood wraps Robinhood's **official, documented** Crypto Trading API. This is se
 
 ## Setup
 
-### 1. Generate API Keys
+### 1. Generate and register a key pair
 
-Go to [robinhood.com/account/crypto](https://robinhood.com/account/crypto) on web classic and create credentials. You'll get:
+Robinhood does not issue you a key pair. You generate one, register the public half at [robinhood.com/account/crypto](https://robinhood.com/account/crypto) → API Trading → Add key, and Robinhood issues an **API key** that identifies it.
 
-- **API key** (starts with `rh-api-`)
-- **Public key** (base64, you upload to Robinhood)
-- **Private key** (base64, you keep secret)
-
-You can also generate a keypair with pyhood:
-
-```python
-from pyhood.crypto.auth import generate_keypair
-
-private_key, public_key = generate_keypair()
-print(f"Private: {private_key}")  # Save securely
-print(f"Public:  {public_key}")   # Upload to Robinhood
+```bash
+python -m pyhood setup crypto
 ```
 
-### 2. Create a Client
+This generates the pair, shows you the public key to register, reads the API key back without echoing it, writes both to `~/.pyhood/crypto.env` at mode `0600`, and confirms with one signed read-only call that Robinhood accepts them. The private key is written straight to disk and never displayed.
+
+See [Setup](setup.md) for the full walkthrough, including rotation with `--force`.
+
+### 2. Create a client
 
 ```python
 from pyhood.crypto import CryptoClient
 
-crypto = CryptoClient(
-    api_key="rh-api-your-key-here",
-    private_key_base64="your-private-key-base64",
-)
+crypto = CryptoClient()
 ```
 
-!!! warning "Never share your private key"
-    Store it in an environment variable or encrypted file. Never commit it to version control.
+Credentials resolve from `RH_CRYPTO_API_KEY` / `RH_CRYPTO_PRIVATE_KEY`, then from `~/.pyhood/crypto.env` (override the path with `PYHOOD_CRYPTO_ENV`). Passing `api_key=` and `private_key_base64=` explicitly still works and takes precedence, but hardcoding them in source is how keys end up committed.
+
+!!! warning "The private key is the credential"
+    Anyone holding it can trade your crypto, and unlike a session token it cannot be refreshed — only revoked. Environment variables take precedence over the credentials file, so a stale `export` will silently shadow it; run `python -m pyhood setup` to see which source is actually in use.
 
 ## Market Data
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,13 +18,21 @@ pip install -e ".[dev]"
 
 ## First Login
 
-hood requires a one-time device approval through the Robinhood mobile app. After that, sessions refresh automatically.
+pyhood requires a one-time device approval through the Robinhood mobile app. After that, sessions refresh automatically.
 
 ### Step 1: Have Your Phone Ready
 
 Open the Robinhood app on your phone. You'll need to tap "Yes, it's me" when prompted.
 
 ### Step 2: Login
+
+```bash
+python -m pyhood setup login
+```
+
+It prompts for your username and password — the password is read without echoing and is never stored — then Robinhood sends a device approval push notification to your phone. Tap **"Yes, it's me"** to approve. The session is saved to `~/.pyhood/session.json`, readable only by you.
+
+To log in from code instead:
 
 ```python
 import pyhood
@@ -36,14 +44,16 @@ session = pyhood.login(
 )
 ```
 
-When you run this, Robinhood will send a device approval push notification to your phone. Tap **"Yes, it's me"** to approve.
+Prefer the command where you can. A password written into a script tends to end up committed.
 
 ### Step 3: Use the Client
 
 ```python
+import pyhood
 from pyhood.client import PyhoodClient
 
-client = PyhoodClient(session)
+# No credentials needed — reuses the stored session.
+client = PyhoodClient(pyhood.login())
 
 # Get a stock quote
 quote = client.get_quote("AAPL")

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,131 @@
+# Setup
+
+pyhood needs two unrelated kinds of credential, depending on what you trade.
+
+| | Session tokens | Crypto API key pair |
+|---|---|---|
+| **Used for** | Stocks, options, futures | Crypto Trading API |
+| **Stored at** | `~/.pyhood/session.json` | `~/.pyhood/crypto.env` |
+| **Obtained by** | Logging in | Generating a key pair and registering the public half |
+| **Lifetime** | Short, refreshes automatically | Long-lived; cannot be refreshed, only revoked |
+| **Set up with** | `python -m pyhood setup login` | `python -m pyhood setup crypto` |
+
+Both are written `0600` inside a `0700` directory, with the mode applied at creation so the contents are never briefly readable by other users on the machine.
+
+## Checking what is configured
+
+```bash
+python -m pyhood setup
+```
+
+```
+Session (main API — stocks, options, futures)
+    /Users/you/.pyhood/session.json (refreshable, saved 1.2h ago)
+
+Crypto API (official Crypto Trading API)
+    source: file
+    /Users/you/.pyhood/crypto.env
+    api key: 43 chars
+    private key: valid Ed25519, 32 bytes
+```
+
+This makes no network calls and prints no secret values — only lengths, byte counts and validity. It exits non-zero when something is missing or malformed, so it works in a health check.
+
+It reports three things that are easy to get wrong and hard to diagnose:
+
+- **Which source is in use.** `RH_CRYPTO_API_KEY` and `RH_CRYPTO_PRIVATE_KEY` take precedence over the file, so a stale `export` left in a shell profile silently shadows correct credentials on disk. The symptom is an authentication failure that looks like a server problem.
+- **Whether the private key is real.** A placeholder pasted from documentation is valid text but not a valid Ed25519 key. This shows up as `not valid base64` or a byte count other than 32.
+- **Whether the files are owner-only.** A credential file readable by other users is reported with the `chmod` to fix it.
+
+## Logging in
+
+```bash
+python -m pyhood setup login
+```
+
+The stored session is tried first — if it is valid, or can be refreshed, no password is needed at all. Only when that fails does it prompt:
+
+```
+Robinhood needs your username and password for a fresh login.
+The password is read without echoing, is not stored, and is not
+written anywhere — only the resulting tokens are saved to disk.
+
+Robinhood email/username: you@email.com
+Password (hidden):
+```
+
+Robinhood then sends a device approval prompt to your phone. Tap **"Yes, it's me"**. If your account uses MFA, the command asks for the code and retries.
+
+Only the resulting tokens are written to disk. The password is not stored anywhere.
+
+## Setting up crypto keys
+
+```bash
+python -m pyhood setup crypto
+```
+
+Robinhood does not issue you a key pair. You generate one, register the public half, and Robinhood issues an API key that identifies it. The command runs the whole exchange:
+
+1. **Generates an Ed25519 key pair** on your machine. The private key is written straight to the credentials file and is never displayed.
+2. **Prints the public key** with the URL to register it: [robinhood.com/account/crypto](https://robinhood.com/account/crypto) → API Trading → Add key.
+3. **Reads the API key** Robinhood issues, without echoing it.
+4. **Writes both** to `~/.pyhood/crypto.env` at mode `0600`.
+5. **Verifies** with one signed read-only call, reporting the account status and fee tier.
+
+Step 5 is the point of the command. Writing a file proves nothing; the question is whether Robinhood accepts the pair. Without it, a mistyped or placeholder key is not discovered until your first real request fails with an authentication error that reads like a service problem.
+
+If credentials already exist, the command refuses to run rather than replacing them — overwriting would orphan a key that still works. Pass `--force` when you actually intend to rotate.
+
+```bash
+python -m pyhood setup crypto --force
+```
+
+Use `--no-verify` to skip the live check, for example when registering the public key on a different machine from the one that will use it.
+
+## Doing it by hand
+
+Neither command is required. `~/.pyhood/crypto.env` is a plain env file:
+
+```
+RH_CRYPTO_API_KEY=the-key-robinhood-issued
+RH_CRYPTO_PRIVATE_KEY=the-private-key-you-generated
+```
+
+```bash
+chmod 600 ~/.pyhood/crypto.env
+```
+
+and the session can be established from code:
+
+```python
+import pyhood
+
+session = pyhood.login(username="you@email.com", password="...", timeout=90)
+```
+
+## How secrets are handled
+
+The behaviour these commands commit to:
+
+- Secrets are read with `getpass`, so they do not echo and do not enter shell history.
+- **There are no options for passing secrets.** No `--password`, no `--api-key`. Command-line arguments are visible to every process on the machine through `ps`, and your shell records them.
+- The crypto private key goes from generation directly to disk. It is never printed, not once.
+- Nothing secret is printed back. Reports show lengths, byte counts and validity.
+- Credential files are created `0600` inside a `0700` directory, with the mode applied at `open()` rather than by a `chmod` afterwards, so there is no window where the contents are world-readable.
+
+## Programmatic use
+
+The same functions are importable, which is what the tests use:
+
+```python
+from pyhood.onboarding import crypto_status, session_status, print_status
+
+if not session_status()["exists"]:
+    raise SystemExit("run: python -m pyhood setup login")
+
+status = crypto_status()
+if not status["private_key_valid"]:
+    raise SystemExit(f"crypto credentials at {status['path']} are not usable")
+```
+
+Neither `crypto_status()` nor `session_status()` returns a secret value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ theme:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Setup: setup.md
   - Migrating from robin_stocks: migrating-from-robin-stocks.md
   - Authentication: authentication.md
   - Usage:
@@ -52,6 +53,7 @@ nav:
     - PyhoodClient: api/client.md
     - CryptoClient: api/crypto.md
     - Authentication: api/auth.md
+    - Setup: api/onboarding.md
     - Models: api/models.md
     - Exceptions: api/exceptions.md
   - Contributing: contributing.md

--- a/pyhood/__main__.py
+++ b/pyhood/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for `python -m pyhood`.
+
+See :mod:`pyhood.onboarding` for the commands.
+"""
+
+import sys
+
+from pyhood.onboarding import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyhood/onboarding.py
+++ b/pyhood/onboarding.py
@@ -1,0 +1,424 @@
+"""Guided setup for the credentials pyhood needs.
+
+pyhood uses two unrelated kinds of credential:
+
+- **Session tokens** (``~/.pyhood/session.json``) for the main Robinhood API,
+  obtained by logging in. Short-lived and refreshable.
+- **A Crypto API key pair** (``~/.pyhood/crypto.env``) for the official Crypto
+  Trading API. Long-lived and *not* refreshable — a leaked private key can
+  trade until it is revoked.
+
+Run interactively::
+
+    python -m pyhood setup           # what is configured, and what is not
+    python -m pyhood setup crypto    # generate and register a key pair
+    python -m pyhood setup login     # obtain session tokens
+
+Handling of secrets, which the rest of this module is built around:
+
+- Secrets are read with :func:`getpass.getpass`, so they do not echo and do not
+  enter shell history. There are deliberately no ``--api-key`` or ``--password``
+  options: command-line arguments are visible to every process on the machine
+  via ``ps`` and are recorded by the shell.
+- The crypto private key is generated locally and written straight to disk. It
+  is never displayed, not even once.
+- Nothing secret is printed back. Reports show lengths, byte counts and
+  validity — never values.
+- Credential files are written ``0600`` inside a ``0700`` directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+import json
+import stat
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from pyhood.crypto.credentials import (
+    API_KEY_VAR,
+    PRIVATE_KEY_VAR,
+    credentials_path,
+    credentials_source,
+    load_credentials,
+)
+from pyhood.secure_files import write_private
+
+#: Where Robinhood manages Crypto API keys.
+KEY_MANAGEMENT_URL = "https://robinhood.com/account/crypto"
+
+#: Valid raw sizes for an Ed25519 private key: a 32-byte seed, or a seed
+#: concatenated with its public key.
+ED25519_KEY_SIZES = (32, 64)
+
+Printer = Callable[[str], Any]
+Prompt = Callable[[str], str]
+
+
+# ── Status ───────────────────────────────────────────────────────────
+
+
+def _file_mode(path: Path) -> int | None:
+    """Permission bits of a file, or None if it does not exist."""
+    try:
+        return stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        return None
+
+
+def _owner_only(mode: int | None) -> bool:
+    """Whether a mode denies all access to group and other."""
+    return mode is not None and not mode & 0o077
+
+
+def crypto_status() -> dict[str, Any]:
+    """Describe the stored crypto credentials without revealing them.
+
+    Returns:
+        Keys: ``source`` ('environment', 'file' or 'none'), ``path``,
+        ``exists``, ``mode``, ``owner_only``, ``api_key_chars``,
+        ``private_key_bytes`` and ``private_key_valid``.
+    """
+    path = credentials_path()
+    mode = _file_mode(path)
+    info: dict[str, Any] = {
+        "source": credentials_source(),
+        "path": path,
+        "exists": path.is_file(),
+        "mode": mode,
+        "owner_only": _owner_only(mode),
+        "api_key_chars": 0,
+        "private_key_bytes": None,
+        "private_key_valid": False,
+    }
+
+    try:
+        api_key, private_key = load_credentials()
+    except FileNotFoundError:
+        return info
+
+    info["api_key_chars"] = len(api_key)
+    try:
+        raw = base64.b64decode(private_key, validate=True)
+    except Exception:
+        return info
+    info["private_key_bytes"] = len(raw)
+    info["private_key_valid"] = len(raw) in ED25519_KEY_SIZES
+    return info
+
+
+def session_status() -> dict[str, Any]:
+    """Describe the stored session without revealing any token."""
+    from pyhood.auth import DEFAULT_TOKEN_DIR, DEFAULT_TOKEN_FILE
+
+    path = DEFAULT_TOKEN_DIR / DEFAULT_TOKEN_FILE
+    mode = _file_mode(path)
+    info: dict[str, Any] = {
+        "path": path,
+        "exists": path.is_file(),
+        "mode": mode,
+        "owner_only": _owner_only(mode),
+        "has_refresh_token": False,
+        "age_hours": None,
+    }
+    if not info["exists"]:
+        return info
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return info
+
+    info["has_refresh_token"] = bool(data.get("refresh_token"))
+    saved_at = data.get("saved_at")
+    if isinstance(saved_at, (int, float)):
+        info["age_hours"] = round((time.time() - saved_at) / 3600, 1)
+    return info
+
+
+def _permissions_note(info: dict[str, Any]) -> str:
+    """A warning line when a credential file is readable by others."""
+    if not info["exists"] or info["owner_only"]:
+        return ""
+    return (
+        f"    ! mode {info['mode']:04o} — readable by other users on this "
+        f"machine. Run: chmod 600 {info['path']}"
+    )
+
+
+def print_status(out: Printer = print) -> int:
+    """Report what is configured. Reads nothing over the network.
+
+    Returns:
+        0 if both credential kinds are usable, 1 otherwise.
+    """
+    session = session_status()
+    crypto = crypto_status()
+
+    out("Session (main API — stocks, options, futures)")
+    if session["exists"]:
+        age = session["age_hours"]
+        age_text = f", saved {age}h ago" if age is not None else ""
+        refresh = "refreshable" if session["has_refresh_token"] else "no refresh token"
+        out(f"    {session['path']} ({refresh}{age_text})")
+        note = _permissions_note(session)
+        if note:
+            out(note)
+    else:
+        out("    not configured — run: python -m pyhood setup login")
+
+    out("")
+    out("Crypto API (official Crypto Trading API)")
+    if crypto["source"] == "none":
+        out("    not configured — run: python -m pyhood setup crypto")
+    else:
+        out(f"    source: {crypto['source']}")
+        if crypto["source"] == "file":
+            out(f"    {crypto['path']}")
+            note = _permissions_note(crypto)
+            if note:
+                out(note)
+        out(f"    api key: {crypto['api_key_chars']} chars")
+        if crypto["private_key_valid"]:
+            out(f"    private key: valid Ed25519, {crypto['private_key_bytes']} bytes")
+        elif crypto["private_key_bytes"] is not None:
+            out(
+                f"    ! private key: {crypto['private_key_bytes']} bytes — expected "
+                f"{' or '.join(str(n) for n in ED25519_KEY_SIZES)}. This is not a real key."
+            )
+        else:
+            out("    ! private key: not valid base64. This is a placeholder, not a real key.")
+
+    if crypto["source"] == "environment" and crypto["path"].is_file():
+        out("")
+        out(
+            f"    Note: {API_KEY_VAR}/{PRIVATE_KEY_VAR} are set in the environment, "
+            f"so {crypto['path']} is being ignored."
+        )
+
+    usable = session["exists"] and crypto["source"] != "none" and crypto["private_key_valid"]
+    return 0 if usable else 1
+
+
+# ── Crypto setup ─────────────────────────────────────────────────────
+
+
+def _verify_crypto(out: Printer) -> int:
+    """Make one signed read-only call to prove the credentials work."""
+    out("")
+    out("Verifying against the live API...")
+    try:
+        from pyhood.crypto import CryptoClient
+
+        account = CryptoClient().get_account()
+    except Exception as e:
+        out(f"    FAILED — {type(e).__name__}: {e}")
+        out("")
+        out("    The key pair was saved, but Robinhood did not accept it. Usually:")
+        out("      - the public key has not been registered yet, or")
+        out("      - the API key was mistyped, or")
+        out(f"      - stale {API_KEY_VAR}/{PRIVATE_KEY_VAR} exports are shadowing the file.")
+        return 1
+    out(f"    OK — authenticated. Account status: {account.status}, fee tier: {account.fee_tier}.")
+    return 0
+
+
+def setup_crypto(
+    force: bool = False,
+    verify: bool = True,
+    secret_prompt: Prompt = getpass.getpass,
+    out: Printer = print,
+) -> int:
+    """Generate a Crypto API key pair and store it.
+
+    The private key is generated on this machine and written directly to the
+    credentials file — it is never displayed. Only the public key is shown,
+    which is the half Robinhood needs.
+
+    Args:
+        force: Replace an existing credentials file. Without this, an existing
+            file is left alone, since overwriting it would revoke working keys.
+        verify: Make one signed read-only call afterwards to confirm the pair
+            is accepted.
+        secret_prompt: Reads the API key. Injected for testing.
+        out: Receives progress output. Injected for testing.
+
+    Returns:
+        Process exit code — 0 on success.
+    """
+    from pyhood.crypto.auth import generate_keypair
+
+    path = credentials_path()
+    if path.is_file() and not force:
+        out(f"{path} already exists.")
+        out("Re-run with --force to replace it. Your existing keys keep working until you do.")
+        return 1
+
+    if credentials_source() == "environment":
+        out(
+            f"Note: {API_KEY_VAR} and {PRIVATE_KEY_VAR} are set in your environment. "
+            f"They take precedence over the file this writes, so unset them "
+            f"afterwards or the new key pair will be ignored."
+        )
+        out("")
+
+    out("Step 1 — generating an Ed25519 key pair on this machine.")
+    out("")
+    private_key, public_key = generate_keypair()
+
+    out("Step 2 — register this PUBLIC key with Robinhood:")
+    out(f"    {KEY_MANAGEMENT_URL}  ->  API Trading  ->  Add key")
+    out("")
+    out(f"    {public_key}")
+    out("")
+    out("Robinhood will then show you an API key. Copy it.")
+    out("")
+
+    api_key = secret_prompt("Step 3 — paste the API key Robinhood issued (hidden): ").strip()
+    if not api_key:
+        out("Nothing entered — no credentials were saved.")
+        return 1
+
+    write_private(path, f"{API_KEY_VAR}={api_key}\n{PRIVATE_KEY_VAR}={private_key}\n")
+    out("")
+    out(f"Saved to {path}, readable only by you.")
+    out("The private key went straight from generation to disk and was never displayed.")
+
+    if verify:
+        return _verify_crypto(out)
+    return 0
+
+
+# ── Login setup ──────────────────────────────────────────────────────
+
+
+def setup_login(
+    prompt: Prompt = input,
+    secret_prompt: Prompt = getpass.getpass,
+    out: Printer = print,
+) -> int:
+    """Obtain session tokens, reusing an existing session where possible.
+
+    A stored session that is still valid, or that can be refreshed, needs no
+    password at all — so that is tried first.
+
+    Args:
+        prompt: Reads the username and any MFA code. Injected for testing.
+        secret_prompt: Reads the password. Injected for testing.
+        out: Receives progress output. Injected for testing.
+
+    Returns:
+        Process exit code — 0 on success.
+    """
+    from pyhood import login
+    from pyhood.exceptions import AuthError, MFARequiredError
+
+    status = session_status()
+    if status["exists"]:
+        out(f"Found a stored session at {status['path']}.")
+        out("Trying it first — a valid or refreshable session needs no password.")
+        try:
+            login()
+        except Exception as e:
+            out(f"    Could not reuse it ({type(e).__name__}). Falling back to a full login.")
+        else:
+            out("    OK — the stored session works. Nothing else to do.")
+            return 0
+        out("")
+
+    out("Robinhood needs your username and password for a fresh login.")
+    out("The password is read without echoing, is not stored, and is not")
+    out("written anywhere — only the resulting tokens are saved to disk.")
+    out("")
+
+    username = prompt("Robinhood email/username: ").strip()
+    if not username:
+        out("Nothing entered — no login attempted.")
+        return 1
+    password = secret_prompt("Password (hidden): ")
+    if not password:
+        out("Nothing entered — no login attempted.")
+        return 1
+
+    out("")
+    out("Logging in. Approve the device in your Robinhood app if prompted.")
+    try:
+        try:
+            login(username, password)
+        except MFARequiredError:
+            code = prompt("MFA code: ").strip()
+            login(username, password, mfa_code=code)
+    except AuthError as e:
+        out(f"    FAILED — {type(e).__name__}: {e}")
+        return 1
+
+    saved = session_status()
+    out("")
+    out(f"Logged in. Session saved to {saved['path']}, readable only by you.")
+    return 0
+
+
+# ── Command line ─────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The `python -m pyhood` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="python -m pyhood",
+        description="Set up the credentials pyhood needs.",
+    )
+    from pyhood import __version__
+
+    parser.add_argument("--version", action="version", version=f"pyhood {__version__}")
+
+    commands = parser.add_subparsers(dest="command")
+    setup = commands.add_parser(
+        "setup",
+        help="configure credentials, or report what is configured",
+        description=(
+            "With no target, reports what is configured. Secrets are always "
+            "read interactively — there are no options for passing them, "
+            "because command-line arguments are visible to other processes."
+        ),
+    )
+    setup.add_argument(
+        "target",
+        nargs="?",
+        choices=("crypto", "login"),
+        help="crypto: generate a Crypto API key pair. login: obtain session tokens.",
+    )
+    setup.add_argument(
+        "--force",
+        action="store_true",
+        help="replace existing crypto credentials instead of leaving them alone",
+    )
+    setup.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="skip the signed read-only call that confirms new crypto keys work",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for `python -m pyhood`."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command != "setup":
+        parser.print_help()
+        return 0
+    if args.target == "crypto":
+        return setup_crypto(force=args.force, verify=not args.no_verify)
+    if args.target == "login":
+        return setup_login()
+    return print_status()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,443 @@
+"""Tests for the guided setup commands.
+
+The security properties are the point of these tests: secrets must reach the
+credentials file and nowhere else, files must be owner-only, and existing
+credentials must not be silently replaced.
+"""
+
+import base64
+import json
+import stat
+import time
+
+import pytest
+
+from pyhood import onboarding
+from pyhood.crypto.credentials import API_KEY_VAR, PRIVATE_KEY_VAR
+
+
+@pytest.fixture
+def crypto_env(tmp_path, monkeypatch):
+    """Point crypto credentials at a temp file, with a clean environment."""
+    path = tmp_path / "crypto.env"
+    monkeypatch.setenv("PYHOOD_CRYPTO_ENV", str(path))
+    monkeypatch.delenv(API_KEY_VAR, raising=False)
+    monkeypatch.delenv(PRIVATE_KEY_VAR, raising=False)
+    return path
+
+
+@pytest.fixture
+def session_file(tmp_path, monkeypatch):
+    """Point the session store at a temp directory."""
+    monkeypatch.setattr("pyhood.auth.DEFAULT_TOKEN_DIR", tmp_path)
+    monkeypatch.setattr("pyhood.auth.DEFAULT_TOKEN_FILE", "session.json")
+    return tmp_path / "session.json"
+
+
+class Recorder:
+    """Collects printed lines."""
+
+    def __init__(self):
+        self.lines = []
+
+    def __call__(self, line=""):
+        self.lines.append(str(line))
+
+    @property
+    def text(self):
+        return "\n".join(self.lines)
+
+
+def write_creds(path, api_key="abc123", private_key=None):
+    if private_key is None:
+        private_key = base64.b64encode(b"k" * 32).decode()
+    path.write_text(f"{API_KEY_VAR}={api_key}\n{PRIVATE_KEY_VAR}={private_key}\n")
+    path.chmod(0o600)
+    return private_key
+
+
+class TestCryptoStatus:
+    def test_reports_shape_not_values(self, crypto_env):
+        private_key = write_creds(crypto_env, api_key="k" * 43)
+
+        info = onboarding.crypto_status()
+
+        assert info["source"] == "file"
+        assert info["api_key_chars"] == 43
+        assert info["private_key_bytes"] == 32
+        assert info["private_key_valid"] is True
+        # The values themselves are never part of the report.
+        assert private_key not in json.dumps(info, default=str)
+        assert "k" * 43 not in json.dumps(info, default=str)
+
+    def test_detects_placeholder_credentials(self, crypto_env):
+        """The failure that motivated this command: a pasted placeholder."""
+        write_creds(crypto_env, api_key="your-key", private_key="your-private-key")
+
+        info = onboarding.crypto_status()
+
+        assert info["private_key_valid"] is False
+
+    def test_short_but_valid_base64_is_rejected(self, crypto_env):
+        write_creds(crypto_env, private_key=base64.b64encode(b"short").decode())
+
+        info = onboarding.crypto_status()
+
+        assert info["private_key_bytes"] == 5
+        assert info["private_key_valid"] is False
+
+    def test_missing_file(self, crypto_env):
+        info = onboarding.crypto_status()
+
+        assert info["source"] == "none"
+        assert info["exists"] is False
+        assert info["private_key_valid"] is False
+
+    def test_environment_shadows_file(self, crypto_env, monkeypatch):
+        write_creds(crypto_env)
+        monkeypatch.setenv(API_KEY_VAR, "from-env")
+        monkeypatch.setenv(PRIVATE_KEY_VAR, base64.b64encode(b"e" * 32).decode())
+
+        assert onboarding.crypto_status()["source"] == "environment"
+
+
+class TestSessionStatus:
+    def test_reports_refreshability_and_age(self, session_file):
+        session_file.write_text(json.dumps({
+            "access_token": "secret-access",
+            "token_type": "Bearer",
+            "refresh_token": "secret-refresh",
+            "device_token": "dev",
+            "saved_at": time.time() - 7200,
+        }))
+        session_file.chmod(0o600)
+
+        info = onboarding.session_status()
+
+        assert info["exists"] is True
+        assert info["has_refresh_token"] is True
+        assert info["age_hours"] == pytest.approx(2.0, abs=0.1)
+        assert info["owner_only"] is True
+        assert "secret-access" not in json.dumps(info, default=str)
+        assert "secret-refresh" not in json.dumps(info, default=str)
+
+    def test_missing_file(self, session_file):
+        assert onboarding.session_status()["exists"] is False
+
+    def test_corrupt_file_does_not_raise(self, session_file):
+        session_file.write_text("not json")
+
+        info = onboarding.session_status()
+
+        assert info["exists"] is True
+        assert info["has_refresh_token"] is False
+
+    def test_flags_world_readable_session(self, session_file):
+        session_file.write_text(json.dumps({"refresh_token": "r", "saved_at": time.time()}))
+        session_file.chmod(0o644)
+
+        assert onboarding.session_status()["owner_only"] is False
+
+
+class TestPrintStatus:
+    def test_unconfigured_points_at_the_commands(self, crypto_env, session_file):
+        out = Recorder()
+
+        assert onboarding.print_status(out=out) == 1
+        assert "python -m pyhood setup login" in out.text
+        assert "python -m pyhood setup crypto" in out.text
+
+    def test_configured_reports_success(self, crypto_env, session_file):
+        write_creds(crypto_env)
+        session_file.write_text(json.dumps({
+            "refresh_token": "r", "saved_at": time.time(),
+        }))
+        session_file.chmod(0o600)
+        out = Recorder()
+
+        assert onboarding.print_status(out=out) == 0
+
+    def test_warns_about_loose_permissions(self, crypto_env, session_file):
+        write_creds(crypto_env)
+        crypto_env.chmod(0o644)
+        out = Recorder()
+
+        onboarding.print_status(out=out)
+
+        assert "chmod 600" in out.text
+
+    def test_warns_when_environment_shadows_file(self, crypto_env, session_file, monkeypatch):
+        write_creds(crypto_env)
+        monkeypatch.setenv(API_KEY_VAR, "from-env")
+        monkeypatch.setenv(PRIVATE_KEY_VAR, base64.b64encode(b"e" * 32).decode())
+        out = Recorder()
+
+        onboarding.print_status(out=out)
+
+        assert "being ignored" in out.text
+
+
+class TestSetupCrypto:
+    def test_writes_owner_only_credentials(self, crypto_env):
+        out = Recorder()
+
+        code = onboarding.setup_crypto(
+            verify=False, secret_prompt=lambda _: "issued-api-key", out=out,
+        )
+
+        assert code == 0
+        assert stat.S_IMODE(crypto_env.stat().st_mode) == 0o600
+        contents = crypto_env.read_text()
+        assert f"{API_KEY_VAR}=issued-api-key" in contents
+        assert PRIVATE_KEY_VAR in contents
+
+    def test_private_key_is_never_printed(self, crypto_env):
+        """The generated private key must reach the file and nothing else."""
+        out = Recorder()
+
+        onboarding.setup_crypto(
+            verify=False, secret_prompt=lambda _: "issued-api-key", out=out,
+        )
+
+        stored = dict(
+            line.split("=", 1) for line in crypto_env.read_text().splitlines() if line
+        )
+        private_key = stored[PRIVATE_KEY_VAR]
+        assert private_key
+        assert private_key not in out.text
+        # The API key the user pasted is not echoed back either.
+        assert "issued-api-key" not in out.text
+
+    def test_public_key_is_printed(self, crypto_env):
+        out = Recorder()
+
+        onboarding.setup_crypto(
+            verify=False, secret_prompt=lambda _: "issued-api-key", out=out,
+        )
+
+        assert onboarding.KEY_MANAGEMENT_URL in out.text
+        # A base64 Ed25519 public key is 44 characters.
+        assert any(len(word) == 44 for line in out.lines for word in line.split())
+
+    def test_refuses_to_overwrite_without_force(self, crypto_env):
+        original = crypto_env
+        write_creds(original, api_key="existing-key")
+        out = Recorder()
+
+        code = onboarding.setup_crypto(
+            verify=False, secret_prompt=lambda _: "new-key", out=out,
+        )
+
+        assert code == 1
+        assert "existing-key" in crypto_env.read_text()
+        assert "--force" in out.text
+
+    def test_force_replaces(self, crypto_env):
+        write_creds(crypto_env, api_key="existing-key")
+
+        code = onboarding.setup_crypto(
+            force=True, verify=False, secret_prompt=lambda _: "new-key", out=Recorder(),
+        )
+
+        assert code == 0
+        assert "existing-key" not in crypto_env.read_text()
+
+    def test_empty_input_saves_nothing(self, crypto_env):
+        out = Recorder()
+
+        code = onboarding.setup_crypto(
+            verify=False, secret_prompt=lambda _: "  ", out=out,
+        )
+
+        assert code == 1
+        assert not crypto_env.exists()
+
+    def test_warns_when_environment_would_shadow_the_new_keys(self, crypto_env, monkeypatch):
+        monkeypatch.setenv(API_KEY_VAR, "stale")
+        monkeypatch.setenv(PRIVATE_KEY_VAR, "stale")
+        out = Recorder()
+
+        onboarding.setup_crypto(
+            verify=False, secret_prompt=lambda _: "new-key", out=out,
+        )
+
+        assert "take precedence" in out.text
+
+    def test_verification_failure_is_reported(self, crypto_env, monkeypatch):
+        class Boom:
+            def __init__(self, *a, **k):
+                raise RuntimeError("Authentication failed")
+
+        monkeypatch.setattr("pyhood.crypto.CryptoClient", Boom)
+        out = Recorder()
+
+        code = onboarding.setup_crypto(secret_prompt=lambda _: "new-key", out=out)
+
+        assert code == 1
+        assert "FAILED" in out.text
+        # The keys are still on disk — the user only needs to register them.
+        assert crypto_env.is_file()
+
+    def test_verification_success(self, crypto_env, monkeypatch):
+        class Account:
+            status = "active"
+            fee_tier = "1"
+
+        class Client:
+            def __init__(self, *a, **k):
+                pass
+
+            def get_account(self):
+                return Account()
+
+        monkeypatch.setattr("pyhood.crypto.CryptoClient", Client)
+        out = Recorder()
+
+        code = onboarding.setup_crypto(secret_prompt=lambda _: "new-key", out=out)
+
+        assert code == 0
+        assert "OK" in out.text
+
+
+class TestSetupLogin:
+    def test_reuses_a_working_session_without_prompting(self, session_file, monkeypatch):
+        session_file.write_text(json.dumps({"refresh_token": "r", "saved_at": time.time()}))
+        monkeypatch.setattr("pyhood.login", lambda *a, **k: object())
+
+        def fail(_):
+            raise AssertionError("should not prompt when the session works")
+
+        out = Recorder()
+        code = onboarding.setup_login(prompt=fail, secret_prompt=fail, out=out)
+
+        assert code == 0
+        assert "Nothing else to do" in out.text
+
+    def test_falls_back_to_a_full_login(self, session_file, monkeypatch):
+        session_file.write_text(json.dumps({"refresh_token": "r", "saved_at": time.time()}))
+        calls = []
+
+        def fake_login(username=None, password=None, **kwargs):
+            if username is None:
+                raise RuntimeError("cached session dead")
+            calls.append((username, password))
+            return object()
+
+        monkeypatch.setattr("pyhood.login", fake_login)
+        out = Recorder()
+
+        code = onboarding.setup_login(
+            prompt=lambda _: "me@example.com",
+            secret_prompt=lambda _: "hunter2",
+            out=out,
+        )
+
+        assert code == 0
+        assert calls == [("me@example.com", "hunter2")]
+
+    def test_password_is_not_echoed(self, session_file, monkeypatch):
+        monkeypatch.setattr("pyhood.login", lambda *a, **k: object())
+        out = Recorder()
+
+        onboarding.setup_login(
+            prompt=lambda _: "me@example.com",
+            secret_prompt=lambda _: "hunter2",
+            out=out,
+        )
+
+        assert "hunter2" not in out.text
+
+    def test_mfa_is_requested_and_retried(self, session_file, monkeypatch):
+        from pyhood.exceptions import MFARequiredError
+
+        attempts = []
+
+        def fake_login(username=None, password=None, mfa_code=None, **kwargs):
+            attempts.append(mfa_code)
+            if mfa_code is None:
+                raise MFARequiredError("mfa required")
+            return object()
+
+        monkeypatch.setattr("pyhood.login", fake_login)
+
+        code = onboarding.setup_login(
+            prompt=lambda p: "123456" if "MFA" in p else "me@example.com",
+            secret_prompt=lambda _: "hunter2",
+            out=Recorder(),
+        )
+
+        assert code == 0
+        assert attempts == [None, "123456"]
+
+    def test_auth_failure_returns_nonzero(self, session_file, monkeypatch):
+        from pyhood.exceptions import AuthError
+
+        def fake_login(*a, **k):
+            raise AuthError("bad credentials")
+
+        monkeypatch.setattr("pyhood.login", fake_login)
+        out = Recorder()
+
+        code = onboarding.setup_login(
+            prompt=lambda _: "me@example.com",
+            secret_prompt=lambda _: "wrong",
+            out=out,
+        )
+
+        assert code == 1
+        assert "FAILED" in out.text
+
+    def test_empty_username_attempts_nothing(self, session_file, monkeypatch):
+        def fail(*a, **k):
+            raise AssertionError("should not log in")
+
+        monkeypatch.setattr("pyhood.login", fail)
+
+        code = onboarding.setup_login(
+            prompt=lambda _: "", secret_prompt=fail, out=Recorder(),
+        )
+
+        assert code == 1
+
+
+class TestCommandLine:
+    def test_no_arguments_prints_help(self, capsys):
+        assert onboarding.main([]) == 0
+        assert "setup" in capsys.readouterr().out
+
+    def test_setup_without_target_reports_status(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(onboarding, "print_status", lambda: called.append(True) or 0)
+
+        assert onboarding.main(["setup"]) == 0
+        assert called
+
+    def test_setup_crypto_routes_with_flags(self, monkeypatch):
+        seen = {}
+
+        def fake(force, verify):
+            seen.update(force=force, verify=verify)
+            return 0
+
+        monkeypatch.setattr(onboarding, "setup_crypto", fake)
+
+        assert onboarding.main(["setup", "crypto", "--force", "--no-verify"]) == 0
+        assert seen == {"force": True, "verify": False}
+
+    def test_setup_login_routes(self, monkeypatch):
+        monkeypatch.setattr(onboarding, "setup_login", lambda: 0)
+
+        assert onboarding.main(["setup", "login"]) == 0
+
+    def test_rejects_unknown_target(self):
+        with pytest.raises(SystemExit):
+            onboarding.main(["setup", "nonsense"])
+
+    def test_no_option_accepts_a_secret(self):
+        """Secrets must never be passable as arguments — argv is world-visible."""
+        parser = onboarding.build_parser()
+        actions = [a for a in parser._subparsers._group_actions[0].choices["setup"]._actions]
+        flags = {opt for a in actions for opt in a.option_strings}
+
+        for leaky in ("--api-key", "--password", "--private-key", "--token"):
+            assert leaky not in flags


### PR DESCRIPTION
Promotes the throwaway key-generation script into the package.

The motivation is concrete rather than aesthetic. The README's key-generation snippet printed the private key to the terminal, where it lands in scrollback, and its copy-pasteable env-file template was at one point run literally — writing an 8-character "api key" and a 16-character "private key" to `~/.pyhood/crypto.env`. Nothing detected it. The next signed request failed with a 401 that read like a service problem.

```bash
python -m pyhood setup           # what is configured, and what is not
python -m pyhood setup crypto    # generate and register a key pair
python -m pyhood setup login     # obtain session tokens
```

**`setup crypto`** generates an Ed25519 pair on the local machine, prints only the public half with the registration URL, reads the API key Robinhood issues without echoing it, writes both owner-only, then makes one signed read-only call to confirm the pair is accepted. That last step is the point — writing a file proves nothing, and without it a bad key isn't discovered until a real request fails.

**`setup login`** tries the stored session first, so a valid or refreshable one needs no password at all. It prompts only when that fails, handling MFA and device approval.

**`setup`** with no target reports which source credentials resolve from, file permissions, and whether the private key is a real Ed25519 key. No network calls; lengths and validity only, never values. Exits non-zero when something is missing, so it works in a health check.

```
$ python -m pyhood setup
Session (main API — stocks, options, futures)
    /Users/you/.pyhood/session.json (refreshable, saved 1.2h ago)

Crypto API (official Crypto Trading API)
    source: file
    /Users/you/.pyhood/crypto.env
    api key: 43 chars
    private key: valid Ed25519, 32 bytes
```

## Handling of secrets

- Read with `getpass` — no echo, no shell history.
- **No `--password` or `--api-key` options exist.** Arguments are visible to every process via `ps` and are recorded by the shell. There is a test asserting no such option can be added.
- The crypto private key goes from generation directly to disk. Never displayed.
- Credential files created `0600` inside a `0700` directory, mode applied at `open()`.
- Existing crypto credentials are not replaced without `--force` — overwriting would orphan a key that still works.

## Deliberately not a console script

This is `python -m pyhood`, not a `pyhood` binary on `PATH`. It keeps the project a library rather than repositioning it as a CLI, and a console-script entry point remains a pure addition later if that's wanted.

The module is `pyhood/onboarding.py`, not `pyhood/setup.py`, to avoid the setuptools collision.

## Docs

New Setup page in the nav, plus an API reference page. README Install / Quick Start / Authentication / Crypto sections reworked. `docs/getting-started.md` and `docs/crypto.md` no longer demonstrate hardcoded credentials or printing the private key.

Also corrects the README portfolio example, which still called `get_portfolio_historicals()` after 0.11.0 made it raise `APIError`.

## Testing

34 new tests, 346 total, ruff clean. The security-relevant ones assert that the generated private key never reaches stdout, that the pasted API key is not echoed back, that files land at `0600`, that placeholder credentials are detected, and that no option can carry a secret.

Verified by hand end to end against a temp credentials path (`-rw-------`, private key absent from output) and confirmed the overwrite guard leaves real credentials untouched.