### PR TITLE
chore: release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to pyhood will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.0] - 2026-08-09
+
+Adds a command line. `pyhood setup login` and `pyhood setup crypto` replace the copy-paste snippets that previously lived in the README — including one that printed your Crypto API private key to the terminal.
 
 ### Added
+- **`pyhood` command** — installed as a console script, and equivalent to `python -m pyhood`
+  - `pyhood version` prints the installed version
+  - Suggested commands in output match how pyhood was invoked, rather than always naming the module form
 - **`pyhood setup`** — guided credential setup, replacing the copy-paste snippets in the README
   - `setup login` establishes a session. The stored session is tried first, so a valid or refreshable one needs no password at all; only when that fails does it prompt, handling MFA and device approval.
   - `setup crypto` generates an Ed25519 key pair, shows only the public half for registration, reads the API key Robinhood issues, writes both owner-only, and then makes one signed read-only call to confirm the pair is accepted. That last step is the point: writing a file proves nothing, and without it a mistyped or placeholder key is not discovered until a real request fails with an authentication error that reads like a service outage.

--- a/pyhood/__init__.py
+++ b/pyhood/__init__.py
@@ -1,6 +1,6 @@
 """pyhood — A modern, reliable Python client for the Robinhood API."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 from pyhood.auth import login, logout, refresh
 from pyhood.client import PyhoodClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = [
 
 [project]
 name = "pyhood"
-version = "0.11.0"
+version = "0.12.0"
 description = "A modern, reliable Python client for the Robinhood API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts 0.12.0. Consolidates the `Unreleased` changelog section and bumps `pyproject.toml` and `pyhood/__init__.py`.

**This release exists because 0.11.0 has no command line.** The README documents `pyhood setup login`, but the published 0.11.0 wheel contains no `__main__.py` and no `onboarding.py` — the setup command landed in #39, after the v0.11.0 tag was cut. Anyone following the README today gets:

```
No module named pyhood.__main__; 'pyhood' is a package and cannot be directly executed
```

## What ships

- **`pyhood` command** — console script plus `python -m pyhood`; `pyhood version`, `pyhood setup`, `pyhood setup login`, `pyhood setup crypto`
- **Verification examples** — `examples/verify_stocks.py`, `examples/verify_crypto.py`
- **`CryptoAccount.fee_tier` fix** — was always empty; fees arrive as a `fee_tier_status` object
- **Ctrl-C at a credential prompt** no longer prints a traceback
- **`setup login`** explains device approval before asking for a password
- **Corrected install instructions** — PEP 668 and the macOS Python 3.9 trap
- **Python 3.14** in CI and the classifiers

## Verified against a clean-room install of the built wheel

```
$ pyhood version
pyhood 0.12.0
$ python -m pyhood version
pyhood 0.12.0
$ pyhood setup
Session (main API — stocks, options, futures)
    not configured — run: pyhood setup login
```

357 tests, ruff clean, wheel 66 KB and sdist 106 KB.