### PR TITLE
docs: verify IPO Access against a live offering; fix PyPI logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `get_ipo_access_allocation_results()` 404s before allocations are decided, which is correct behaviour rather than a fault.
   - **`has_ipo_offerings()` reports False during a live offering** once its order book closes — it reflects offerings still open for requests, not whether an IPO exists. Documented, along with the reliable signal: instruments of `type` `pre_ipo` carrying an `ipo_access_status`. Cards and order entry still resolve by instrument ID at that point, so the two must not be chained.
 
+### Fixed
+- **The logo was a broken image on PyPI.** The README referenced it with a repo-relative path, which PyPI does not resolve — it renders the README but has no access to repository assets. It now uses an absolute raw URL. Takes effect with the next release.
+
 ### Removed
 - The three terminal recordings embedded in the README. They did not read well on the page. The VHS tapes that produce them are kept under `assets/demo/`, so restoring them later is one command per recording rather than a re-shoot.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **IPO Access verified against a live offering.** Four of these endpoints had never been seen with real data, because they 404 when no offering exists. RVII (Robinhood Ventures Fund II) was in its order book on 2026-08-12 at `ipo_access_status` `price_finalized`, listing the next day.
+  - `get_ipo_access_cards()` and `get_ipo_access_order_entry()` return populated data; both shapes are now asserted in tests rather than guessed. The card carries the ticker in `title` and the offer price in `subtitle`; `order_entry.context` carries `phase`, `instrument_symbol`, `ipo_access_cob_deadline`, `has_cob_deadline_passed`, `user_is_enrolled` and `available_buying_power`.
+  - `get_ipo_access_summary()` is now marked unconfirmed. It 404s against a live offering, as do seven other spellings of the path on the same base that serves `web_order_entry` successfully. Either the route is stage-specific or the path is wrong.
+  - `get_ipo_access_allocation_results()` 404s before allocations are decided, which is correct behaviour rather than a fault.
+  - **`has_ipo_offerings()` reports False during a live offering** once its order book closes — it reflects offerings still open for requests, not whether an IPO exists. Documented, along with the reliable signal: instruments of `type` `pre_ipo` carrying an `ipo_access_status`. Cards and order entry still resolve by instrument ID at that point, so the two must not be chained.
+
 ### Removed
 - The three terminal recordings embedded in the README. They did not read well on the page. The VHS tapes that produce them are kept under `assets/demo/`, so restoring them later is one command per recording rather than a re-shoot.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ That makes pyhood a better fit for cron jobs, scheduled portfolio scripts, dashb
 - **Safer session storage** - JSON session persistence instead of `pickle`.
 - **Rate limiting and retries** - request throttling and retry behavior built in.
 - **Clear auth errors** - explicit exceptions for timeouts, MFA, expired tokens, and device approval failures.
-- **Maintained test suite** - CI across Python 3.10 through 3.13.
+- **Maintained test suite** - 360 tests, CI across Python 3.10 through 3.14.
 
 ## How pyhood compares
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pyhood
 
 <div align="center">
-<img src="assets/logo-tight.png" alt="pyhood logo" width="200">
+<img src="https://raw.githubusercontent.com/jamestford/pyhood/main/assets/logo-tight.png" alt="pyhood logo" width="200">
 
 **A modern Python client for the Robinhood API, built for scripts that need to stay authenticated.**
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Built for automated trading — with auth that doesn't break, proper error handl
 - 📊 **Options-first** — Deep options chain support with Greeks, volume/OI analysis, and earnings integration.
 - 📈 **Futures trading** — Contract details, real-time quotes, order history, and P&L calculation for futures.
 - 🪙 **Dual API support** — Wraps both Robinhood's unofficial stocks/options API and their official Crypto Trading API.
-- 🧪 **Tested and maintained** — 170+ tests, CI across Python 3.10-3.13, linted with ruff.
+- 🧪 **Tested and maintained** — 360 tests, CI across Python 3.10-3.14, linted with ruff.
 
 ## Quick Example
 

--- a/pyhood/client.py
+++ b/pyhood/client.py
@@ -2561,7 +2561,17 @@ class PyhoodClient:
         return self._session.get(urls.IPO_ACCESS_LIST)
 
     def has_ipo_offerings(self) -> bool:
-        """Whether any IPO Access offerings are currently available."""
+        """Whether any IPO Access offering is open for share requests.
+
+        Note:
+            This is narrower than "an IPO exists". The list only carries
+            offerings whose order book is still open, so an upcoming IPO
+            reports False once its book closes. Verified against RVII on
+            2026-08-12: the instrument was live at `ipo_access_status`
+            `price_finalized` and listing the next day, while this returned
+            False. To detect an offering regardless of stage, look for
+            instruments with `type` `pre_ipo` and an `ipo_access_status`.
+        """
         data = self.get_ipo_access_list()
         return bool(data) and "empty_state" not in data
 
@@ -2572,7 +2582,14 @@ class PyhoodClient:
             instrument_ids: An instrument ID, or a list of them.
 
         Returns:
-            List of card dicts (`instrument_id`, `name`, `title`, `action`).
+            List of card dicts. Shape verified against a live offering
+            (RVII, 2026-08-12): `instrument_id`, `name`, `title` (the
+            ticker), `subtitle` (the price, e.g. `'$25.00'`), `accent_color`,
+            `action` (a deeplink) and `logo_images`.
+
+        Note:
+            Cards resolve by instrument ID at any stage, including after the
+            order book has closed and `has_ipo_offerings()` reports False.
         """
         data = self._session.get(urls.ipo_access_cards_url(instrument_ids))
         return data.get("results", []) if isinstance(data, dict) else []
@@ -2580,9 +2597,14 @@ class PyhoodClient:
     def get_ipo_access_summary(self, instrument_id: str) -> dict:
         """Get an IPO's summary view model — company, dates and price range.
 
-        Note:
-            Only exists while an offering is live; returns 404 otherwise. This
-            response shape has not been observed against a real offering.
+        Warning:
+            Unconfirmed. This returned 404 against a live offering (RVII,
+            2026-08-12, phase `price_finalized`), as did seven other spellings
+            of the path on the same base that serves `web_order_entry`
+            successfully. Either the route is stage-specific — reachable only
+            while the order book is open — or this path is wrong. Prefer
+            `get_ipo_access_order_entry()`, whose `context` carries the
+            symbol, phase, cut-off deadline and enrolment state.
         """
         return self._session.get(urls.ipo_access_summary_url(instrument_id))
 
@@ -2591,12 +2613,26 @@ class PyhoodClient:
     ) -> dict:
         """Get an IPO's order-entry view model — eligibility and price range.
 
-        The `context` section carries eligibility, enrolment, the cut-off
-        deadline and your buying power.
+        Returns:
+            The raw view model. Shape verified against a live offering (RVII,
+            2026-08-12): `account_number`, `instrument_id`, `context`,
+            `form_state`, `order_entry_view_model`, `trade_receipt_view_model`,
+            `action_required_view_model` and `ipoa_new_orders_blocked_details`.
+
+            `context` is the useful part: `phase` (e.g. `'price_finalized'`),
+            `instrument_symbol`, `instrument_url`, `ipo_access_quote`,
+            `ipo_access_cob_deadline`, `has_cob_deadline_passed`,
+            `user_is_enrolled`, `account_type`, `existing_order` and
+            `available_buying_power`.
+
+            `trade_receipt_view_model` is None until an order exists.
 
         Note:
-            Only exists while an offering is live; returns 404 otherwise. This
-            response shape has not been observed against a real offering.
+            This is the most informative of the IPO endpoints and the one to
+            reach for — it resolves after the order book closes, when
+            `get_ipo_access_list()` has already reverted to its empty state.
+            Requesting shares is not wrapped; an IPO Access order is an
+            ordinary equity order.
         """
         return self._session.get(
             urls.ipo_access_order_entry_url(instrument_id, account_number)
@@ -2606,7 +2642,11 @@ class PyhoodClient:
         """Get how many shares you were allocated in an IPO you requested.
 
         Note:
-            This response shape has not been observed against a real offering.
+            Returns 404 before allocations are decided — confirmed against a
+            live offering the day before it listed (RVII, 2026-08-12). That is
+            the endpoint behaving correctly rather than a fault: there is no
+            allocation to report until after pricing. The populated shape
+            remains unobserved, since it needs a filled request.
         """
         return self._session.get(urls.ipo_access_allocation_results_url(instrument_id))
 

--- a/tests/test_ipo.py
+++ b/tests/test_ipo.py
@@ -195,3 +195,118 @@ class TestIpoAccessOrders:
 
         client.get_ipo_access_orders(start_date="2026-01-01")
         assert "created_at%5Bgte%5D" in responses.calls[0].request.url
+
+
+class TestLiveOfferingShapes:
+    """Shapes captured from a live offering — RVII on 2026-08-12.
+
+    Before this, four of the IPO endpoints had never been seen against a real
+    offering, because they 404 when none exists. RVII was in its order book
+    with `ipo_access_status` `price_finalized`, listing the next day. Account
+    identifiers and balances are replaced with placeholders.
+    """
+
+    INSTRUMENT_ID = "e958d09f-0a47-4468-b1e4-e66b6c3598fa"
+
+    CARD = {
+        "instrument_id": INSTRUMENT_ID,
+        "name": "Robinhood Ventures Fund II",
+        "title": "RVII",
+        "subtitle": "$25.00",
+        "accent_color": {"light": "fg", "dark": "fg"},
+        "action": {
+            "action_type": "deeplink",
+            "action_data": {"uri": f"robinhood://instrument?id={INSTRUMENT_ID}"},
+        },
+        "logo_images": {
+            "dark": {"@1x": "https://cdn.robinhood.com/app_assets/ipoa/x/night.png"},
+            "light": {"@1x": "https://cdn.robinhood.com/app_assets/ipoa/x/day.png"},
+        },
+    }
+
+    ORDER_ENTRY = {
+        "account_number": "ACCOUNT_NUMBER",
+        "instrument_id": INSTRUMENT_ID,
+        "context": {
+            "phase": "price_finalized",
+            "instrument_symbol": "RVII",
+            "instrument_url": "https://api.robinhood.com/instruments/x/",
+            "ipo_access_quote": {"price": "25.00"},
+            "ipo_access_cob_deadline": "2026-08-12T23:00:00Z",
+            "has_cob_deadline_passed": True,
+            "user_is_enrolled": False,
+            "account_type": "individual",
+            "existing_order": None,
+            "available_buying_power": {"currency_code": "USD", "amount": "0.00"},
+        },
+        "form_state": {
+            "form_state_id": "price_finalized2525",
+            "form_invalid_alert": {"title": "Price update"},
+        },
+        "order_entry_view_model": {
+            "title": "Request shares",
+            "rows": [],
+            "limit_options": [],
+            "order_summary": {},
+            "buying_power_description": "",
+            "disclaimer": "",
+        },
+        "trade_receipt_view_model": None,
+        "action_required_view_model": None,
+        "ipoa_new_orders_blocked_details": "",
+    }
+
+    @responses.activate
+    def test_card_carries_ticker_and_price(self, client):
+        """`title` is the ticker and `subtitle` the offer price."""
+        responses.add(
+            responses.GET,
+            urls.ipo_access_cards_url(self.INSTRUMENT_ID),
+            json={"results": [self.CARD]},
+            status=200,
+        )
+
+        cards = client.get_ipo_access_cards(self.INSTRUMENT_ID)
+
+        assert len(cards) == 1
+        assert cards[0]["title"] == "RVII"
+        assert cards[0]["subtitle"] == "$25.00"
+        assert cards[0]["instrument_id"] == self.INSTRUMENT_ID
+
+    @responses.activate
+    def test_order_entry_context_is_the_useful_part(self, client):
+        responses.add(
+            responses.GET,
+            urls.ipo_access_order_entry_url(self.INSTRUMENT_ID),
+            json=self.ORDER_ENTRY,
+            status=200,
+        )
+
+        vm = client.get_ipo_access_order_entry(self.INSTRUMENT_ID)
+        context = vm["context"]
+
+        assert context["phase"] == "price_finalized"
+        assert context["instrument_symbol"] == "RVII"
+        assert context["has_cob_deadline_passed"] is True
+        assert context["user_is_enrolled"] is False
+        # No order placed, so there is no receipt yet.
+        assert vm["trade_receipt_view_model"] is None
+
+    @responses.activate
+    def test_cards_resolve_after_the_book_closes(self, client):
+        """The list reverts to its empty state; cards still resolve by ID.
+
+        Both were observed on the same offering minutes apart, which is why
+        `has_ipo_offerings()` cannot be used to decide whether to fetch a card.
+        """
+        responses.add(
+            responses.GET, urls.IPO_ACCESS_LIST,
+            json={"empty_state": {"title": "No new IPOs available"}}, status=200,
+        )
+        responses.add(
+            responses.GET, urls.ipo_access_cards_url(self.INSTRUMENT_ID),
+            json={"results": [self.CARD]}, status=200,
+        )
+
+        assert client.has_ipo_offerings() is False
+        assert client.get_ipo_access_cards(self.INSTRUMENT_ID)[0]["title"] == "RVII"


### PR DESCRIPTION
## IPO Access, verified against a live offering

Four of these endpoints had never been seen with real data, because they 404 when no offering exists. RVII (Robinhood Ventures Fund II) was in its order book on 2026-08-12 at `ipo_access_status` `price_finalized`, listing the next day — the first chance to check them.

| Method | Result |
|---|---|
| `get_ipo_access_cards()` | **Populated** — shape verified |
| `get_ipo_access_order_entry()` | **Populated** — shape verified |
| `get_ipo_access_orders()` | Works (0 orders) |
| `get_ipo_access_list()` | Works — empty state |
| `get_ipo_access_summary()` | 404 |
| `get_ipo_access_allocation_results()` | 404 — correct, allocations don't exist yet |
| `get_ipo_access_trade_receipt()` | Untestable — needs a filled order |
| `has_ipo_offerings()` | Returns `False` **during a live offering** |

**The shapes are now asserted in tests from captured payloads rather than guessed.** The card carries the ticker in `title` and the offer price in `subtitle`; `order_entry.context` carries `phase`, `instrument_symbol`, `ipo_access_cob_deadline`, `has_cob_deadline_passed`, `user_is_enrolled` and `available_buying_power`. That is the failure mode behind the whole 0.11.0 batch — tests mocking shapes the API never returns — so pinning the real ones matters more than the coverage number.

**`has_ipo_offerings()` is misleading and is now documented as such.** It reflects offerings whose order book is still open, not whether an IPO exists. Cards and order entry both still resolve by instrument ID at that point — verified minutes apart — so the two must not be chained. There's a test pinning exactly that combination. The reliable signal is an instrument of `type` `pre_ipo` carrying an `ipo_access_status`.

**`get_ipo_access_summary()` is marked unconfirmed rather than dead.** It 404s against a live offering, as do seven other spellings of the path on the same base that serves `web_order_entry` successfully. Either the route is stage-specific or our path is wrong — not declaring it dead on a single observation.

Account identifiers and balances are placeholders in the fixtures.

## Also

- **The logo was a broken image on PyPI.** The README referenced it with a repo-relative path, which PyPI does not resolve. Now an absolute raw URL. Takes effect at the next release.
- **Stale claims corrected** — the README and docs index advertised CI across 3.10–3.13 and "170+ tests". Both are 3.10–3.14 and 360 tests.

360 tests, ruff clean.