### PR TITLE
chore: release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to pyhood will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.1] - 2026-08-12
+
+A documentation release. No behaviour changes — cut so the corrected README reaches PyPI, which renders the description baked into the uploaded distribution rather than the one on `main`.
 
 ### Changed
 - **IPO Access verified against a live offering.** Four of these endpoints had never been seen with real data, because they 404 when no offering exists. RVII (Robinhood Ventures Fund II) was in its order book on 2026-08-12 at `ipo_access_status` `price_finalized`, listing the next day.
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`has_ipo_offerings()` reports False during a live offering** once its order book closes — it reflects offerings still open for requests, not whether an IPO exists. Documented, along with the reliable signal: instruments of `type` `pre_ipo` carrying an `ipo_access_status`. Cards and order entry still resolve by instrument ID at that point, so the two must not be chained.
 
 ### Fixed
-- **The logo was a broken image on PyPI.** The README referenced it with a repo-relative path, which PyPI does not resolve — it renders the README but has no access to repository assets. It now uses an absolute raw URL. Takes effect with the next release.
+- **The logo was a broken image on PyPI.** The README referenced it with a repo-relative path, which PyPI does not resolve — it renders the README but has no access to repository assets. It now uses an absolute raw URL, which is what this release exists to publish.
 
 ### Removed
 - The three terminal recordings embedded in the README. They did not read well on the page. The VHS tapes that produce them are kept under `assets/demo/`, so restoring them later is one command per recording rather than a re-shoot.

--- a/pyhood/__init__.py
+++ b/pyhood/__init__.py
@@ -1,6 +1,6 @@
 """pyhood — A modern, reliable Python client for the Robinhood API."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 from pyhood.auth import login, logout, refresh
 from pyhood.client import PyhoodClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = [
 
 [project]
 name = "pyhood"
-version = "0.12.0"
+version = "0.12.1"
 description = "A modern, reliable Python client for the Robinhood API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Documentation release. No behaviour changes.

**Why it exists:** PyPI renders the description baked into the uploaded distribution, not the one on `main`. The logo fix merged in #45 had no effect on the project page, where the logo is still a broken image — confirmed in the browser, and by the PyPI JSON API still serving `<img src="assets/logo-tight.png">`.

Shipping 0.12.1:

- Fixes the broken logo on the project page (absolute raw URL)
- Drops three references to terminal recordings that no longer exist in the repo, and never rendered on PyPI anyway
- Publishes the IPO Access verification notes and the corrected Python version claims

Verified in the built sdist before pushing — the packaged README carries the absolute logo URL and zero `.gif` references.

360 tests, ruff clean.